### PR TITLE
Further Messbox bugfixes/changes

### DIFF
--- a/Classes/Source/messbox.c
+++ b/Classes/Source/messbox.c
@@ -103,8 +103,7 @@ static void messbox_draw(t_messbox *x, t_glist *glist){
         {break}\n", x->text_id);
     sys_vgui("bind pre%s <KeyPress-Return> {pdsend {%s bang}\n\
         break}\n", x->text_id, x->x_bind_sym->s_name);
-    sys_vgui("bind pre%s <Shift-KeyPress-Return> {\n\
-    }\n", x->text_id);
+    sys_vgui("bind pre%s <Shift-KeyPress-Return> {#}\n", x->text_id);
     sys_vgui("pack %s -side left -fill both -expand 1\n", x->text_id);
     sys_vgui("pack %s -side bottom -fill both -expand 1\n", x->frame_id);
 //    bind_button_events;
@@ -172,10 +171,13 @@ static void messbox_displace(t_gobj *z, t_glist *glist, int dx, int dy){
     }
 }
 
+static void messbox_key(void *z, t_floatarg f);
+
 static void messbox_select(t_gobj *z, t_glist *glist, int state){
     t_messbox *x = (t_messbox *)z;
     if(state){
         sys_vgui("%s configure -fg blue -state disabled -cursor $cursor_editmode_nothing\n", x->text_id);
+        sys_vgui("%s itemconfigure %x_outline -outline blue\n", x->x_cv_id, (unsigned long)x);
         x->x_selected = 1;
         int x1, y1, x2, y2;
         messbox_getrect(z, glist, &x1, &y1, &x2, &y2);
@@ -195,7 +197,9 @@ static void messbox_select(t_gobj *z, t_glist *glist, int state){
     }
     else{
         sys_vgui("%s configure -fg %s -state normal -cursor xterm\n", x->text_id, x->x_fgcolor);
+        sys_vgui("%s itemconfigure %x_outline -outline black\n", x->x_cv_id, (unsigned long)x);
         sys_vgui("destroy %s\n", x->handle_id);
+        messbox_key(z, 0);
         x->x_selected = 0;
     }
 }

--- a/Classes/Source/messbox.c
+++ b/Classes/Source/messbox.c
@@ -92,6 +92,7 @@ static void messbox_draw(t_messbox *x, t_glist *glist){
     int xpos = text_xpix(&x->x_obj, glist), ypos = text_ypix(&x->x_obj, glist);
     sys_vgui("namespace eval messbox%lx {}\n", x);
     sys_vgui("destroy %s\n", x->frame_id);  // Seems we gotta delete it if it exists
+    sys_vgui("destroy %s\n", x->handle_id);
     sys_vgui("frame %s\n", x->frame_id);
     sys_vgui("text %s -font {{%s} %d %s}  -highlightthickness 0 -bg \"%s\" -fg \"%s\"\n", x->text_id,
         FONT_NAME, x->x_font_size, x->x_font_weight->s_name, x->x_bgcolor, x->x_fgcolor);
@@ -174,10 +175,8 @@ static void messbox_displace(t_gobj *z, t_glist *glist, int dx, int dy){
 static void messbox_select(t_gobj *z, t_glist *glist, int state){
     t_messbox *x = (t_messbox *)z;
     if(state){
-        if(!x->x_selected) {
-            sys_vgui("%s configure -fg blue -state disabled -cursor $cursor_editmode_nothing\n", x->text_id);
-            x->x_selected = 1;
-        }
+        sys_vgui("%s configure -fg blue -state disabled -cursor $cursor_editmode_nothing\n", x->text_id);
+        x->x_selected = 1;
         int x1, y1, x2, y2;
         messbox_getrect(z, glist, &x1, &y1, &x2, &y2);
         sys_vgui("canvas %s -width %d -height %d -bg #ddd -bd 0 \

--- a/Classes/Source/messbox.c
+++ b/Classes/Source/messbox.c
@@ -367,7 +367,7 @@ static void messbox_key(void *z, t_floatarg f){
 }
 
 static int messbox_click(t_gobj *z, t_glist *glist, int xpix, int ypix, int shift, int alt, int dbl, int doit){
-    xpix = ypix = alt = dbl = 0;
+    xpix = ypix = alt = dbl = shift = 0;
     if(doit){
 //        post("do it");
         t_messbox *x = (t_messbox *)z;
@@ -376,8 +376,6 @@ static int messbox_click(t_gobj *z, t_glist *glist, int xpix, int ypix, int shif
         sys_vgui("%s configure -state normal\n", x->text_id);
         sys_vgui("focus %s\n", x->text_id);
         glist_grab(glist, (t_gobj *)x, 0, messbox_key, 0, 0);
-        if(shift)
-            messbox_bang(x);
     }
     return(1);
 }


### PR DESCRIPTION
Fixes a bug introduced in #1018 where the resizing handle wouldn't be deleted when re-opening a minimized window where the messbox was selected. Now the handle is drawn correctly (I don't think it was before that pr)

shift-click doesn't output from messbox anymore (though honestly I'm not sure why this should be taken out?)

the outline of messbox is blue when selected now.

Also fixes a bug where in edit mode if clicking on another object's text after having selected the messbox the text would be entered in both. However, in order to fix this bug now messbox must be clicked after moving it in order to enter text again (similar to the number box or symbol box objects)

I was not able to restore the previous text when the messbox is in a window that's minimized or in a subpatch that gets closed. This is due to pd not having a mechanism to notify tcl objects that a window is being closed at the moment. this would be possible after pure-data/pure-data#1323.

closes #1020 