### PR TITLE
better $0 support and put a newline when ; is set or appended in messbox

### DIFF
--- a/Classes/Source/messbox.c
+++ b/Classes/Source/messbox.c
@@ -266,40 +266,76 @@ static void messbox_bang(t_messbox* x){
 
 static void messbox_append(t_messbox* x,  t_symbol *s, int ac, t_atom *av){
     s = NULL;
+    char buf[40];
+    size_t length;
     sys_vgui("%s configure -state normal\n", x->text_id);
-    for(int i = 0; i < ac; i++){
-        t_symbol *sym = atom_getsymbolarg(i, ac, av);
-        if(sym == &s_) {
-            sys_vgui("%s insert end \"%g \"\n", x->text_id, atom_getfloatarg(i, ac , av));
-        } else if (sym->s_name[0] == '\\' || sym->s_name[0] == '['
-            || sym->s_name[0] == '$') {
-                sys_vgui("%s insert end \"\\%s \"\n", x->text_id, sym->s_name);
-        } else if (sym->s_name[0] == ';') {
-            sys_vgui("%s insert end \\;\\n\n", x->text_id);
-        } else
-            sys_vgui("%s insert end \"%s \"\n", x->text_id, sym->s_name);
+    if(ac){
+        int i;
+        size_t pos;
+        for(i = 0; i < ac; i++){
+            t_symbol *sym = atom_getsymbolarg(i, ac, av);
+            if(sym == &s_) {
+                sys_vgui("%s insert end \"%g \"\n", x->text_id, atom_getfloatarg(i, ac , av));
+            } else{
+                int j = 0;
+                length = 39;
+                for(pos = 0; pos < strlen(sym->s_name); pos++) {
+                    char c = sym->s_name[pos];
+                    if(c == '\\' || c == '[' || c == '$' || c == ';') {
+                        length--;
+                        if(length <= 0) break;
+                        buf[j++] = '\\';
+                    }
+                    length--;
+                    if(length <= 0) break;
+                    buf[j++] = c;
+                }
+                buf[j] = '\0';
+            }
+            if (sym->s_name[pos-1] == ';') {
+                sys_vgui("%s insert end %s\\n\n", x->text_id, buf);
+            } else
+                sys_vgui("%s insert end \"%s \"\n", x->text_id, buf);
+        }
+        sys_vgui("%s yview end-2char\n", x->text_id);
     }
-    sys_vgui("%s yview end-2char\n", x->text_id);
     if(!x->x_active)
         sys_vgui("%s configure -state disabled\n", x->text_id);
 }
 
 static void messbox_set(t_messbox *x, t_symbol *s, int ac, t_atom *av){
     s = NULL;
+    char buf[40];
+    size_t length;
     sys_vgui("%s configure -state normal\n", x->text_id);
     sys_vgui("%s delete 0.0 end \n", x->text_id);
     if(ac){
-        for(int i = 0; i < ac; i++){
+        int i;
+        size_t pos;
+        for(i = 0; i < ac; i++){
             t_symbol *sym = atom_getsymbolarg(i, ac, av);
             if(sym == &s_) {
                 sys_vgui("%s insert end \"%g \"\n", x->text_id, atom_getfloatarg(i, ac , av));
-            } else if (sym->s_name[0] == '\\' || sym->s_name[0] == '['
-            || sym->s_name[0] == '$') {
-                sys_vgui("%s insert end \"\\%s \"\n", x->text_id, sym->s_name);
-            } else if (sym->s_name[0] == ';') {
-                sys_vgui("%s insert end \\;\\n\n", x->text_id);
+            } else{
+                int j = 0;
+                length = 39;
+                for(pos = 0; pos < strlen(sym->s_name); pos++) {
+                    char c = sym->s_name[pos];
+                    if(c == '\\' || c == '[' || c == '$' || c == ';') {
+                        length--;
+                        if(length <= 0) break;
+                        buf[j++] = '\\';
+                    }
+                    length--;
+                    if(length <= 0) break;
+                    buf[j++] = c;
+                }
+                buf[j] = '\0';
+            }
+            if (sym->s_name[pos-1] == ';') {
+                sys_vgui("%s insert end %s\\n\n", x->text_id, buf);
             } else
-                sys_vgui("%s insert end \"%s \"\n", x->text_id, sym->s_name);
+                sys_vgui("%s insert end \"%s \"\n", x->text_id, buf);
         }
         sys_vgui("%s yview end-2char\n", x->text_id);
     }

--- a/Classes/Source/messbox.c
+++ b/Classes/Source/messbox.c
@@ -331,11 +331,11 @@ static void messbox_set(t_messbox *x, t_symbol *s, int ac, t_atom *av){
                     buf[j++] = c;
                 }
                 buf[j] = '\0';
+                if (sym->s_name[pos-1] == ';') {
+                    sys_vgui("%s insert end %s\\n\n", x->text_id, buf);
+                } else
+                    sys_vgui("%s insert end \"%s \"\n", x->text_id, buf);
             }
-            if (sym->s_name[pos-1] == ';') {
-                sys_vgui("%s insert end %s\\n\n", x->text_id, buf);
-            } else
-                sys_vgui("%s insert end \"%s \"\n", x->text_id, buf);
         }
         sys_vgui("%s yview end-2char\n", x->text_id);
     }

--- a/Classes/Source/messbox.c
+++ b/Classes/Source/messbox.c
@@ -229,6 +229,31 @@ static void messbox_proxy_output(t_messbox_proxy* x, t_symbol *s, int ac,
 }
 */
 
+static void messbox_list(t_messbox* x, t_symbol *s, int ac,
+    t_atom *av){
+    s = NULL;
+    char buf[MAXPDSTRING];
+    sprintf(buf, "\\$0 %s", x->x_dollzero->s_name);
+    char symbuf[32]; // should be enough?
+    int i;
+    size_t length = MAXPDSTRING - 1, tmplength;
+    length -= strlen(buf);
+    for(i = 0; i < ac; i++) {
+        sprintf(symbuf, " \\$%i ", i+1);
+        tmplength = strlen(symbuf);
+        length -= tmplength;
+        if (length <= 0) break;
+        strncat(buf, symbuf, tmplength);
+        atom_string(av + i, symbuf, 32);
+        tmplength = strlen(symbuf);
+        length -= tmplength;
+        if (length <= 0) break;
+        strncat(buf, symbuf, tmplength);
+    }
+    sys_vgui("pdsend \"%s [string map {%s} [%s get 0.0 end]]\"\n",
+        x->x_proxy->x_bind_sym->s_name, buf, x->text_id);
+}
+
 static void messbox_proxy_anything(t_messbox_proxy* x, t_symbol *s, int ac,
     t_atom *av){
     outlet_anything(x->p_master->x_obj.ob_outlet, s, ac, av);
@@ -541,6 +566,7 @@ void messbox_setup(void){
 				 sizeof(t_messbox_proxy),
 				 CLASS_PD | CLASS_NOINLET, 0);
     class_addbang(messbox_class, (t_method)messbox_bang);
+    class_addlist(messbox_class, (t_method)messbox_list);
     class_addanything(messbox_proxy_class, (t_method)messbox_proxy_anything);
     class_addmethod(messbox_class, (t_method)messbox_size, gensym("size"), A_GIMME, 0);
     class_addmethod(messbox_class, (t_method)messbox_fontsize, gensym("fontsize"), A_GIMME, 0);


### PR DESCRIPTION
~~$0 still doesn't get escaped in the middle of a symbol from "set" or "append" because it's tricky to find-and-replace in c in order to put the right backslashes in. ~~it will work~~ in the beginning of a symbol though.~~
edit: I was able to just copy the strings and insert a backslash in the appropriate locations

when \\; is entered into "set" or "append" it will insert a newline as well now

~~other arguments such as $1, $2 etc. won't work, but~~ $0 will now get expanded to the right value (hopefully)
the resolution of these values is somewhat ambiguous; should they refer to positional elements of an incoming list, as message boxes do, or should they refer to the arguments of the containing canvas, as objects do? $0 seems to be for an object, but the description of messbox is "GUI message box"