### PR TITLE
Added includes to fix c99 build errors

### DIFF
--- a/Classes/Aliases/lb.c
+++ b/Classes/Aliases/lb.c
@@ -4,6 +4,7 @@
 
 #include "m_pd.h"
 #include "g_canvas.h"
+#include <string.h>
 
 typedef struct _lb{
     t_object    x_ob;

--- a/Classes/Source/allpass.2nd~.c
+++ b/Classes/Source/allpass.2nd~.c
@@ -2,6 +2,7 @@
 
 #include "m_pd.h"
 #include <math.h>
+#include <string.h>
 
 #define PI 3.14159265358979323846
 #define HALF_LOG2 log(2)/2

--- a/Classes/Source/bandstop~.c
+++ b/Classes/Source/bandstop~.c
@@ -2,6 +2,7 @@
 
 #include "m_pd.h"
 #include <math.h>
+#include <string.h>
 
 #define PI 3.14159265358979323846
 #define HALF_LOG2 log(2)/2

--- a/Classes/Source/bicoeff.c
+++ b/Classes/Source/bicoeff.c
@@ -1,6 +1,7 @@
 
 #include "m_pd.h"
-#include "math.h"
+#include <math.h>
+#include <string.h>
 
 #define PI 3.14159265358979323846
 

--- a/Classes/Source/eq~.c
+++ b/Classes/Source/eq~.c
@@ -2,6 +2,7 @@
 
 #include "m_pd.h"
 #include <math.h>
+#include <string.h>
 
 #define PI 3.14159265358979323846
 #define HALF_LOG2 log(2) * 0.5

--- a/Classes/Source/highpass~.c
+++ b/Classes/Source/highpass~.c
@@ -2,6 +2,7 @@
 
 #include "m_pd.h"
 #include <math.h>
+#include <string.h>
 
 #define PI 3.14159265358979323846
 #define HALF_LOG2 log(2)/2

--- a/Classes/Source/impseq~.c
+++ b/Classes/Source/impseq~.c
@@ -1,6 +1,7 @@
 // Porres 2017 from mask~
 
 #include "m_pd.h"
+#include <stdlib.h>
 
 static t_class *impseq_class;
 

--- a/Classes/Source/loadbanger.c
+++ b/Classes/Source/loadbanger.c
@@ -2,6 +2,7 @@
 
 #include "m_pd.h"
 #include "g_canvas.h"
+#include <string.h>
 
 typedef struct _loadbanger{
     t_object    x_ob;

--- a/Classes/Source/lowpass~.c
+++ b/Classes/Source/lowpass~.c
@@ -2,6 +2,7 @@
 
 #include "m_pd.h"
 #include <math.h>
+#include <string.h>
 
 #define PI 3.14159265358979323846
 #define HALF_LOG2 log(2)/2

--- a/Classes/Source/peak~.c
+++ b/Classes/Source/peak~.c
@@ -1,7 +1,8 @@
 // similar to rms~ but outputs peak amplitude
 
 #include "m_pd.h"
-#include "math.h"
+#include <math.h>
+#include <string.h>
 
 #define MAXOVERLAP 32
 #define INITVSTAKEN 64

--- a/Classes/Source/resonant~.c
+++ b/Classes/Source/resonant~.c
@@ -2,6 +2,7 @@
 
 #include "m_pd.h"
 #include <math.h>
+#include <string.h>
 
 #define PI 3.14159265358979323846
 

--- a/Classes/Source/trig.delay~.c
+++ b/Classes/Source/trig.delay~.c
@@ -1,6 +1,7 @@
 // Porres 2017
 
 #include "m_pd.h"
+#include <math.h>
 
 static t_class *trig_delay_class;
 

--- a/Classes/Source/wrap2.c
+++ b/Classes/Source/wrap2.c
@@ -1,7 +1,7 @@
 // Porres 2016
  
 #include "m_pd.h"
-// #include <math.h>
+#include <math.h>
 
 static t_class *wrap2_class;
 


### PR DESCRIPTION
Just tried to compile (on OSX Catalina) via 

```bash
make pdincludepath=/Applications/Studio/Pd-0.51-4.app/Contents/Resources/src
```

I kept getting errors like the examples below. These were easily fixed by adding the required stdlib includes which compilation went smoothly thereafter.


```c
Classes/Source/peak~.c:93:16: error: implicitly declaring library function
      'strcmp' with type 'int (const char *, const char *)'
      [-Werror,-Wimplicit-function-declaration]
            if(strcmp(curarg->s_name, "-db")==0)
               ^
Classes/Source/peak~.c:93:16: note: include the header <string.h> or explicitly
      provide a declaration for 'strcmp'

...


Classes/Source/impseq~.c:282:9: error: implicit declaration of function 'free'
      is invalid in C99 [-Werror,-Wimplicit-function-declaration]
        free(x->impseqs[i].pat);

...


Classes/Source/eq~.c:163:16: error: implicitly declaring library function
      'strcmp' with type 'int (const char *, const char *)'
      [-Werror,-Wimplicit-function-declaration]
            if(strcmp(curarg->s_name, "-bw")==0)
               ^
Classes/Source/eq~.c:163:16: note: include the header <string.h> or explicitly
      provide a declaration for 'strcmp'


...


Classes/Source/highpass~.c:148:16: error: implicitly declaring library function
      'strcmp' with type 'int (const char *, const char *)'
      [-Werror,-Wimplicit-function-declaration]
            if(strcmp(curarg->s_name, "-bw")==0)
               ^
Classes/Source/highpass~.c:148:16: note: include the header <string.h> or
      explicitly provide a declaration for 'strcmp'


...


Classes/Source/lowpass~.c:156:16: error: implicitly declaring library function
      'strcmp' with type 'int (const char *, const char *)'
      [-Werror,-Wimplicit-function-declaration]
            if(strcmp(curarg->s_name, "-bw")==0)
               ^
Classes/Source/lowpass~.c:156:16: note: include the header <string.h> or
      explicitly provide a declaration for 'strcmp'


...


etc..

```