### PR TITLE
#ifndef for utf8.h on non-Windows

### DIFF
--- a/Classes/Source/note.c
+++ b/Classes/Source/note.c
@@ -4,7 +4,10 @@
 #include <ctype.h>
 #include "m_pd.h"
 #include "g_canvas.h"
+
+#ifndef _WIN32
 #include "s_utf8.h"
+#endif
 
 #define NOTE_MINSIZE       8
 #define NOTE_HANDLE_WIDTH  8

--- a/Classes/Source/separate.c
+++ b/Classes/Source/separate.c
@@ -4,6 +4,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifndef _WIN32
+#include "s_utf8.h"
+#endif
+
 typedef struct _separate{
     t_object    x_obj;
     t_symbol   *x_separator;


### PR DESCRIPTION
This fixes compilation issues resp. "utf8.h" on Windows.

Tested to work on Windows and Linux (should work on macOS). 