### PR TITLE
Oscope~ fixes, some MSVC fixes

### DIFF
--- a/Classes/Source/bl.imp2~.c
+++ b/Classes/Source/bl.imp2~.c
@@ -1,10 +1,19 @@
 
 #include "m_pd.h"
+
+#define _USE_MATH_DEFINES
+
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <complex.h>
+
+#if _MSC_VER
+#define t_complex _Dcomplex
+#else
+#define t_complex complex double
+#endif
 
 // TODO: some of these aren't used
 #define LPHASOR      (8*sizeof(uint32_t)) // the phasor logsize
@@ -49,7 +58,7 @@ typedef struct _butter_state{
     t_float s_c2;
 }butter_state;
 
-void butter_bang_smooth (butter_state states[3], t_float input, t_float* output, t_float smooth){
+static void butter_bang_smooth (butter_state states[3], t_float input, t_float* output, t_float smooth){
     for(int i = 0; i < 3; i++){
         butter_state* s = states + i;
         t_float d1t = s->s_ar * s->d1A + s->s_ai * s->d2A + input;
@@ -65,7 +74,7 @@ void butter_bang_smooth (butter_state states[3], t_float input, t_float* output,
     }
 }
 
-void butter_init(butter_state states[3]){
+static void butter_init(butter_state states[3]){
     for(int i = 0; i < 3; i++){
         butter_state* s = states + i;
         s->d1A = s->d1B = s->d2A = s->d2B = 0.0;
@@ -74,15 +83,53 @@ void butter_init(butter_state states[3]){
     }
 }
 
-complex double complex_with_angle(const t_float angle){ return cos(angle) + sin(angle) * I; }
-t_float complex_norm2(const complex double x){return creal(x)*creal(x)+cimag(x)*cimag(x);}
-t_float complex_norm(const complex double x){return sqrt(complex_norm2(x));}
+static t_complex complex_div_f(t_float in1, t_complex in2) {
+    double real = (double)in1 / creal(in2);
+    double imag = (double)in1 / cimag(in2);
+    
+    return (t_complex){real,imag};
+}
 
-void set_butter_hp(butter_state states[3], t_float freq){
-    /*  This member function computes the poles for a highpass butterworth filter.
-     *  The filter is transformed to the digital domain using a bilinear transform.
-     *  Every biquad section is normalized at NY.
-     */
+static t_complex complex_mult(t_complex in1, t_complex in2) {
+    double real = creal(in1) * creal(in2) - cimag(in1) * cimag(in2);
+    double imag = creal(in1) * cimag(in2) + creal(in2) * cimag(in1);
+    return (t_complex){real,imag};
+}
+
+static t_complex complex_div(t_complex in1, t_complex in2)
+ {
+    double real = (creal(in1) * creal(in2) + cimag(in1) * cimag(in2)) / (creal(in2) * creal(in2) + cimag(in2) * cimag(in2));
+    double imag = (cimag(in1) * creal(in2) - creal(in1) * cimag(in2)) / (creal(in2) * creal(in2) + cimag(in2) * cimag(in2));
+    return (t_complex){real,imag};
+ }
+
+static t_complex complex_add(t_complex in1, t_complex in2) {
+    double real = creal(in1) + creal(in2);
+    double imag = cimag(in1) + cimag(in2);
+    return (t_complex){real,imag};
+}
+
+static t_complex complex_subtract(t_complex in1, t_complex in2) {
+    double real = creal(in1) - creal(in2);
+    double imag = cimag(in1) - cimag(in2);
+    return (t_complex){real,imag};
+}
+
+
+static t_complex complex_with_angle(const t_float angle){
+    return (t_complex){cosf(angle), sinf(angle)};
+}
+
+static t_float complex_norm2(const t_complex x){
+    return creal(x) * creal(x) + cimag(x) * cimag(x);
+}
+static t_float complex_norm(const t_complex x){
+    return sqrt(complex_norm2(x));
+}
+
+static void set_butter_hp(butter_state states[3], t_float freq){
+    //  This computes the poles for a highpass butterworth filter, transformed to the
+    // digital domain using a bilinear transform. Every biquad section is normalized at NY.
     t_float epsilon = .0001; // stability guard
     t_float min = 0.0 + epsilon;
     t_float max = 0.5 - epsilon;
@@ -93,21 +140,25 @@ void set_butter_hp(butter_state states[3], t_float freq){
         freq = max;
     // prewarp cutoff frequency
     t_float omega = 2.0 * tan(M_PI * freq);
-    complex double pole = complex_with_angle( (2*sections + 1) * M_PI / (4*sections)); // first pole of lowpass filter with omega == 1
-    complex double pole_inc = complex_with_angle(M_PI / (2*sections)); // phasor to get to next pole, see Porat p. 331
-    complex double b = -1;  //normalize at NY
-    complex double c = 1;  //all zeros will be at DC
+    t_complex pole = complex_with_angle( (2*sections + 1) * M_PI / (4*sections)); // first pole of lowpass filter with omega == 1
+    t_complex pole_inc = complex_with_angle(M_PI / (2*sections)); // phasor to get to next pole, see Porat p. 331
+    t_complex b = (t_complex){-1.0, 0.0}; // normalize at NY
+    t_complex c = (t_complex){1.0, 0.0};  // all zeros will be at DC
     for(int i = 0; i < sections; i++){
         butter_state* s = states + i;
         // setup the biquad with the computed pole and zero and unit gain at NY
-        pole *= pole_inc;            // comp next (lowpass) pole
-        complex double a = omega/pole;
+        pole = complex_mult(pole, pole_inc);            // comp next (lowpass) pole
+        t_complex a = complex_div_f(omega, pole);
         s->ar = creal(a);
         s->ai = cimag(a);
         s->c0 = 1.0;
         s->c1 = 2.0 * (creal(a) - creal(b));
         s->c2 = (complex_norm2(a) - complex_norm2(b) - s->c1 * creal(a)) / cimag(a);
-        complex double invComplexGain = ((c-a)*(c-conj(a)))/((c-b)*(c-conj(b)));
+        t_complex invComplexGain = complex_div(
+        complex_mult(complex_subtract(c, a), complex_subtract(c, conj(a))),
+        complex_mult(complex_subtract(c, b), complex_subtract(c, conj(b)))
+        );
+        
         t_float invGain = complex_norm(invComplexGain);
         s->c0 *= invGain;
         s->c1 *= invGain;

--- a/Classes/Source/datetime.c
+++ b/Classes/Source/datetime.c
@@ -4,7 +4,7 @@
 #include <time.h>
 
 #if (defined __WIN32__)
-# if (defined __i386__) && (defined __MINGW32__)
+# if (defined __i386__) && (defined __MINGW32__) && (!defined _MSC_VER)
 // unless compiling under mingw/32bit, we want USE_TIMEB in redmond-land
 # else
 #  define USE_TIMEB

--- a/Classes/Source/oscope~.c
+++ b/Classes/Source/oscope~.c
@@ -40,7 +40,6 @@ typedef struct _scope{
     float           x_currx, x_curry;
     int             x_select;
     int             x_width, x_height;
-    int             x_drawstyle;
     int             x_delay;
     int             x_trigmode;
     int             x_bufsize, x_lastbufsize;
@@ -427,12 +426,6 @@ static void scope_delay(t_scope *x, t_floatarg f){
         x->x_delay = delay;
 }
 
-static void scope_drawstyle(t_scope *x, t_floatarg f){
-    int drawstyle = (int)f;
-    if(x->x_drawstyle != drawstyle)
-        x->x_drawstyle = drawstyle;
-}
-
 static void scope_trigger(t_scope *x, t_floatarg f){
     int trig = f < 0 ? 0 : f > 2 ? 2 : (int)f;
     if(x->x_trigmode != trig){
@@ -703,21 +696,16 @@ static t_int *scope_perform(t_int *w){
                     t_float f1 = *in1++;
                     t_float f2 = *in2++;
                     if(x->x_xymode == 1){ // CHECKED
-                        if(!x->x_drawstyle){
-                            if((currx<0 && (f1<currx || f1>-currx)) || (currx>0 && (f1>currx || f1<-currx)))
+                        
+                        if((currx<0 && (f1<currx || f1>-currx)) || (currx>0 && (f1>currx || f1<-currx)))
                                 currx = f1;
-                        }
-                        else if(f1 < currx)
-                            currx = f1;
+        
                         curry = 0.;
                     }
                     else if(x->x_xymode == 2){
-                        if(!x->x_drawstyle){
-                            if((curry<0 && (f2<curry || f2>-curry)) || (curry>0 && (f2>curry || f2<-curry)))
-                                curry = f2;
-                        }
-                        else if(f2 < curry)
+                        if((curry<0 && (f2<curry || f2>-curry)) || (curry>0 && (f2>curry || f2<-curry)))
                             curry = f2;
+
                         currx = 0.;
                     }
                     else{
@@ -846,7 +834,7 @@ static void scope_properties(t_gobj *z, t_glist *owner){
         dim %d width: %d height: \
         buf %d cal: %d bfs: \
         rng %g min: %g max: \
-        del %d del: drs %d drs: \
+        del %d del: \
         {%s} rcv: trg %d tmd: %g tlv: \
         dim_mins %d %d \
         cal_min_max %d %d bfs_min_max %d %d \
@@ -855,7 +843,7 @@ static void scope_properties(t_gobj *z, t_glist *owner){
         x->x_width/x->x_zoom, x->x_height/x->x_zoom,
         x->x_period, x->x_bufsize,
         x->x_min, x->x_max,
-        x->x_delay, x->x_drawstyle,
+        x->x_delay,
         x->x_rcv_raw->s_name, 
         x->x_trigmode, x->x_triglevel,
         SCOPE_MINSIZE, SCOPE_MINSIZE,
@@ -885,13 +873,12 @@ static void scope_ok(t_scope *x, t_symbol *s, int ac, t_atom *av){
     SETFLOAT(undo+4, x->x_min);
     SETFLOAT(undo+5, x->x_max);
     SETFLOAT(undo+6, x->x_delay);
-    SETFLOAT(undo+7, x->x_drawstyle);
-    SETFLOAT(undo+8, x->x_trigmode);
-    SETFLOAT(undo+9, x->x_triglevel);
-    SETFLOAT(undo+10, ((int)x->x_bg[0] << 16) + ((int)x->x_bg[1] << 8) + (int)x->x_bg[2]);
-    SETFLOAT(undo+11, ((int)x->x_gg[0] << 16) + ((int)x->x_gg[1] << 8) + (int)x->x_gg[2]);
-    SETFLOAT(undo+12, ((int)x->x_fg[0] << 16) + ((int)x->x_fg[1] << 8) + (int)x->x_fg[2]);
-    SETSYMBOL(undo+13, x->x_receive);
+    SETFLOAT(undo+7, x->x_trigmode);
+    SETFLOAT(undo+8, x->x_triglevel);
+    SETFLOAT(undo+9, ((int)x->x_bg[0] << 16) + ((int)x->x_bg[1] << 8) + (int)x->x_bg[2]);
+    SETFLOAT(undo+10, ((int)x->x_gg[0] << 16) + ((int)x->x_gg[1] << 8) + (int)x->x_gg[2]);
+    SETFLOAT(undo+11, ((int)x->x_fg[0] << 16) + ((int)x->x_fg[1] << 8) + (int)x->x_fg[2]);
+    SETSYMBOL(undo+12, x->x_receive);
     pd_undo_set_objectstate(x->x_glist, (t_pd*)x, gensym("dialog"), 14, undo, ac, av);
     int width = atom_getintarg(0, ac, av);
     int height = atom_getintarg(1, ac, av);
@@ -900,18 +887,16 @@ static void scope_ok(t_scope *x, t_symbol *s, int ac, t_atom *av){
     float minval = (float)atom_getfloatarg(4, ac, av);
     float maxval = (float)atom_getfloatarg(5, ac, av);
     int delay = atom_getintarg(6, ac, av);
-    int drawstyle = atom_getintarg(7, ac, av);
-    int trigmode = atom_getintarg(8, ac, av);
-    int triglevel = atom_getintarg(9, ac, av);
-    int bgcol = (int)scope_getcolorarg(10, ac, av);
-    int grcol = (int)scope_getcolorarg(11, ac, av);
-    int fgcol = (int)scope_getcolorarg(12, ac, av);
-    t_symbol *rcv = atom_getsymbolarg(13, ac, av);
+    int trigmode = atom_getintarg(7, ac, av);
+    int triglevel = atom_getintarg(8, ac, av);
+    int bgcol = (int)scope_getcolorarg(9, ac, av);
+    int grcol = (int)scope_getcolorarg(10, ac, av);
+    int fgcol = (int)scope_getcolorarg(11, ac, av);
+    t_symbol *rcv = atom_getsymbolarg(12, ac, av);
     scope_period(x, period);
     scope_bufsize(x, bufsize);
     scope_range(x, minval, maxval);
     scope_delay(x, delay);
-    scope_drawstyle(x, drawstyle);
     scope_receive(x, rcv);
     scope_trigger(x, trigmode);
     scope_triglevel(x, triglevel);
@@ -987,7 +972,7 @@ static void *scope_new(t_symbol *s, int ac, t_atom *av){
     x->x_flag = x->x_r_flag = x->x_rcv_set = x->x_select = 0;
     x->x_phase = x->x_bufphase = x->x_precount = 0;
     float width = 200, height = 100, period = 256, bufsize = x->x_lastbufsize = 128; // def values
-    float minval = -1, maxval = 1, delay = 0, drawstyle = 0, trigger = 0, triglevel = 0; // def
+    float minval = -1, maxval = 1, delay = 0, trigger = 0, triglevel = 0; // def
     unsigned char bgred = 190, bggreen = 190, bgblue = 190;    // default bg color
     unsigned char fgred = 30, fggreen = 30, fgblue = 30; // default fg color
     unsigned char grred = 160, grgreen = 160, grblue = 160;   // default grid color
@@ -1148,11 +1133,6 @@ static void *scope_new(t_symbol *s, int ac, t_atom *av){
                 delay = atom_getfloatarg(1, ac, av);
                 ac-=2, av+=2;
             }
-/*            else if(sym == gensym("-drawstyle") && ac >= 2){
-                x->x_flag = 1;
-                drawstyle = atom_getfloatarg(1, ac, av);
-                ac-=2, av+=2;
-            }*/
             else if(sym == gensym("-trigger") && ac >= 2){
                 x->x_flag = 1;
                 trigger = atom_getfloatarg(1, ac, av);
@@ -1222,7 +1202,6 @@ static void *scope_new(t_symbol *s, int ac, t_atom *av){
     else
         x->x_min = minval, x->x_max = maxval;
     x->x_delay = delay < 0 ? 0 : delay;
-    x->x_drawstyle = drawstyle;
     x->x_triglevel = triglevel;
     x->x_trigmode = trigger < 0 ? 0 : trigger > 2 ? 2 : (int)trigger;
     if(x->x_trigmode == 0) // no trigger
@@ -1258,7 +1237,6 @@ void oscope_tilde_setup(void){
     class_addmethod(scope_class, (t_method)scope_dim, gensym("dim"), A_GIMME, 0);
     class_addmethod(scope_class, (t_method)scope_range, gensym("range"), A_FLOAT, A_FLOAT, 0);
     class_addmethod(scope_class, (t_method)scope_delay, gensym("delay"), A_FLOAT, 0);
-    class_addmethod(scope_class, (t_method)scope_drawstyle, gensym("drawstyle"), A_FLOAT, 0);
     class_addmethod(scope_class, (t_method)scope_trigger, gensym("trigger"), A_FLOAT, 0);
     class_addmethod(scope_class, (t_method)scope_triglevel, gensym("triglevel"), A_FLOAT, 0);
     class_addmethod(scope_class, (t_method)scope_fgcolor, gensym("fgcolor"),
@@ -1290,3 +1268,5 @@ void oscope_tilde_setup(void){
     scope_widgetbehavior.w_clickfn    = (t_clickfn)scope_click;
     #include "oscope~_dialog.c"
 }
+
+

--- a/Classes/Source/oscope~_dialog.c
+++ b/Classes/Source/oscope~_dialog.c
@@ -108,8 +108,6 @@ sys_gui("set var_scope_del [concat scope_del_$vid]\n");
 sys_gui("global $var_scope_del\n");
 sys_gui("set var_scope_tr_level [concat scope_tr_level_$vid]\n");
 sys_gui("global $var_scope_tr_level\n");
-sys_gui("set var_scope_draw_style [concat scope_draw_style_$vid]\n");
-sys_gui("global $var_scope_draw_style\n");
 sys_gui("set var_scope_width_init [concat scope_width_init_$vid]\n");
 sys_gui("global $var_scope_width_init\n");
 sys_gui("set var_scope_height_init [concat scope_height_init_$vid]\n");
@@ -249,8 +247,6 @@ sys_gui("set var_scope_tr_mode [concat scope_tr_mode_$vid]\n");
 sys_gui("global $var_scope_tr_mode\n");
 sys_gui("set var_scope_tr_level [concat scope_tr_level_$vid]\n");
 sys_gui("global $var_scope_tr_level\n");
-sys_gui("set var_scope_draw_style [concat scope_draw_style_$vid]\n");
-sys_gui("global $var_scope_draw_style\n");
 // receive
 sys_gui("set var_scope_rcv [concat scope_rcv_$vid]\n");
 sys_gui("global $var_scope_rcv\n");
@@ -271,7 +267,6 @@ sys_gui("[eval concat $$var_scope_bufsize] \\\n");
 sys_gui("[eval concat $$var_scope_min_range] \\\n");
 sys_gui("[eval concat $$var_scope_max_range] \\\n");
 sys_gui("[eval concat $$var_scope_del] \\\n");
-sys_gui("[eval concat $$var_scope_draw_style] \\\n");
 sys_gui("[eval concat $$var_scope_tr_mode] \\\n");
 sys_gui("[eval concat $$var_scope_tr_level] \\\n");
 sys_gui("[eval concat $$var_scope_bcol] \\\n");
@@ -296,7 +291,7 @@ sys_gui("proc ::dialog_scope::pdtk_scope_dialog {mytoplevel \\\n");
 sys_gui("dim_header width width_label height height_label \\\n");
 sys_gui("buf_header cal cal_label bufsize bufsize_label \\\n");
 sys_gui("range_header min_range min_range_label max_range max_range_label \\\n");
-sys_gui("del_header del del_label draw_style_header draw_style draw_style_label\\\n");
+sys_gui("del_header del del_label\\\n");
 sys_gui("rcv rcv_label\\\n");
 sys_gui("trg_header tr_mode tr_mode_label tr_level tr_level_label \\\n");
 sys_gui("dim_mins width_min height_min \\\n");
@@ -328,8 +323,6 @@ sys_gui("set var_scope_tr_mode2 [concat scope_tr_mode2_$vid]\n");
 sys_gui("global $var_scope_tr_mode2\n");
 sys_gui("set var_scope_tr_level [concat scope_tr_level_$vid]\n");
 sys_gui("global $var_scope_tr_level\n");
-sys_gui("set var_scope_draw_style [concat scope_draw_style_$vid]\n");
-sys_gui("global $var_scope_draw_style\n");
 // Receive
 sys_gui("set var_scope_rcv [concat scope_rcv_$vid]\n");
 sys_gui("global $var_scope_rcv\n");
@@ -378,7 +371,6 @@ sys_gui("set $var_scope_bufsize $bufsize\n");
 sys_gui("set $var_scope_min_range $min_range\n");
 sys_gui("set $var_scope_max_range $max_range\n");
 sys_gui("set $var_scope_del $del\n");
-sys_gui("set $var_scope_draw_style $draw_style\n");
 // Receive
 sys_gui("if {$rcv == \"empty\"} {set $var_scope_rcv [format \"\"]} else {set $var_scope_rcv [string map {{\\ } \" \"} $rcv]}\n");
 sys_gui("set $var_scope_tr_mode $tr_mode\n");
@@ -412,7 +404,6 @@ sys_gui("set min_range_label [_ \"Lower:\"]\n");
 sys_gui("set max_range_label [_ \"Upper:\"]\n");
 sys_gui("set del_header [_ \"Delay:\"]\n");
 sys_gui("set del_label [_ \"Delay:\"]\n");
-sys_gui("set draw_style_label [_ \"Alternate Drawstyle:\"]\n");
 sys_gui("set rcv_label [_ \"Receive Symbol:\"]\n");
 sys_gui("set tr_mode_label [_ \"Trigger Mode:\"]\n");
 sys_gui("set tr_mode0_label [_ \"None\"]\n");
@@ -495,19 +486,15 @@ sys_gui("-label \"Up\" -command \"::dialog_scope::scope_trigger_mode $mytoplevel
 sys_gui("$mytoplevel.tr_mode_popup add command \\\n");
 sys_gui("-label \"Down\" -command \"::dialog_scope::scope_trigger_mode $mytoplevel 2\"\n");
 sys_gui("bind $mytoplevel.trg.tr_mode.trb <Button> [list tk_popup $mytoplevel.tr_mode_popup %X %Y]\n");
-//delay & drawstyle
+//delay
 sys_gui("labelframe $mytoplevel.misc -borderwidth 1 -pady 8 -text [_ \"Other Settings:\"]\n");
 sys_gui("pack $mytoplevel.misc -side top -pady 5 -fill x\n");
 sys_gui("frame $mytoplevel.misc.fr\n");
 sys_gui("label $mytoplevel.misc.fr.del_lab -text [_ $del_label]\n");
 sys_gui("entry $mytoplevel.misc.fr.del_ent -textvariable $var_scope_del -width 7\n");
 sys_gui("label $mytoplevel.misc.fr.dummy1 -text \"\" -width 4\n");
-sys_gui("label $mytoplevel.misc.fr.draw_style_lab -text [_ $draw_style_label]\n");
-sys_gui("checkbutton $mytoplevel.misc.fr.draw_style_chk -variable $var_scope_draw_style \\\n");
-sys_gui("-command \"::dialog_scope::apply_and_rebind_return $mytoplevel\" \n");
 sys_gui("pack $mytoplevel.misc.fr -side left -expand 1\n");
-sys_gui("pack $mytoplevel.misc.fr.del_lab $mytoplevel.misc.fr.del_ent \\\n");
-sys_gui("$mytoplevel.misc.fr.dummy1 $mytoplevel.misc.fr.draw_style_lab $mytoplevel.misc.fr.draw_style_chk -side left\n");
+sys_gui("pack $mytoplevel.misc.fr.del_lab $mytoplevel.misc.fr.del_ent\n");
 
 // Receive
 sys_gui("labelframe $mytoplevel.rcv -borderwidth 1 -pady 8 -text [_ \"Receive:\"]\n");
@@ -522,7 +509,7 @@ sys_gui("pack $mytoplevel.rcv.fr.rcv_lab $mytoplevel.rcv.fr.rcv_ent -side left \
 sys_gui("labelframe $mytoplevel.colors -borderwidth 1 -text [_ \"Colors:\"] -padx 5 -pady 5\n");
 sys_gui("pack $mytoplevel.colors -fill x\n");
 sys_gui("frame $mytoplevel.colors.scopevis \n");
-sys_gui("pack $mytoplevel.colors.scopevis -side top -pady 10\n");
+sys_gui("pack $mytoplevel.colors.scopevis -side right -pady 30 -padx 15\n"); 
 sys_gui("canvas $mytoplevel.colors.scopevis.cv -width 81 -height 65 \\\n");
 sys_gui("-relief flat -highlightthickness 0\n");
 sys_gui("pack $mytoplevel.colors.scopevis.cv -in $mytoplevel.colors.scopevis\n");


### PR DESCRIPTION
This PR contains 3 fixes:

- [oscope~]: No more drawstyle, better layout for properties dialog
- [datetime]: Fix for MSVC compilation
- [bl.imp2~]: Fixes for MSVC compilation and fixed function naming conflict with [bl.imp]

The last two fixes were already included in PlugData because I couldn't compile without it, so it would be nice to have them included in ELSE.