### PR TITLE
dir.c: Fix for crash when compiled with MSVC

### DIFF
--- a/Classes/Source/dir.c
+++ b/Classes/Source/dir.c
@@ -272,6 +272,20 @@ static void *dir_new(t_symbol *s, int ac, t_atom* av){
     while(depth-- && canvas->gl_owner)
         canvas = canvas_getrootfor(canvas->gl_owner);
     x->x_getdir = canvas_getdir(canvas); // default
+    
+// If you compile Pd with MSVC, this will return the location with "\" instead of "/", which is a problem
+#if _MSC_VER 
+    char* getdir_name = strdup(x->x_getdir->s_name);
+
+    for (int i = 0; i < strlen(getdir_name); i++) {
+        if (getdir_name[i] == '\\')
+            getdir_name[i] = '/';
+    }
+
+    x->x_getdir = gensym(getdir_name);
+    free(getdir_name);
+#endif
+    
     strncpy(x->x_directory, x->x_getdir->s_name, MAXPDSTRING); // default
     dirname == &s_ ? dir_loadir(x, x->x_getdir, 1) : dir_loadir(x, dirname, 1);
     x->x_out1 = outlet_new(&x->x_obj, &s_anything);


### PR DESCRIPTION
<img width="618" alt="Screenshot 2022-12-04 at 00 39 26" src="https://user-images.githubusercontent.com/44585538/205466826-0cc85cb7-3455-4517-8da5-7caf9762a257.png">

Fixes this. The problem is that canvas_getdir returns a path with "\" instead of "/" on Windows, which will cause a crash when you do stuff like "strrchr(x->x_directory, '/');"