### PR TITLE
Fixed all naming conflicts with cyclone

### DIFF
--- a/Classes/Aliases/imp2~.c
+++ b/Classes/Aliases/imp2~.c
@@ -169,7 +169,7 @@ static t_int *imp2_perform(t_int *w){
 
 
 static void imp2_dsp(t_imp2 *x, t_signal **sp){
-    x->x_hasfeeders = inlet_connection((t_object *)x, x->x_glist, 2, &s_signal); // magic feeder flag
+    x->x_hasfeeders = else_magic_inlet_connection((t_object *)x, x->x_glist, 2, &s_signal); // magic feeder flag
     x->x_sr = sp[0]->s_sr;
     if (x->x_hasfeeders){
         dsp_add(imp2_perform, 7, x, sp[0]->s_n,

--- a/Classes/Aliases/imp~.c
+++ b/Classes/Aliases/imp~.c
@@ -33,14 +33,14 @@ static t_int *imp_perform_magic(t_int *w){
 // Magic Start
     int posfreq = x->x_posfreq;
     t_float *scalar = x->x_signalscalar;
-    if (!magic_isnan(*x->x_signalscalar)){
+    if (!else_magic_isnan(*x->x_signalscalar)){
         t_float input_phase = fmod(*scalar, 1);
         if (input_phase < 0)
             input_phase += 1;
         if(input_phase == 0 && x->x_posfreq)
             input_phase = 1;
         x->x_phase = input_phase;
-        magic_setnan(x->x_signalscalar);
+        else_magic_setnan(x->x_signalscalar);
     }
 // Magic End
     double phase = x->x_phase;
@@ -135,7 +135,7 @@ static t_int *imp_perform(t_int *w){
 }
 
 static void imp_dsp(t_imp *x, t_signal **sp){
-    x->x_hasfeeders = inlet_connection((t_object *)x, x->x_glist, 1, &s_signal); // magic feeder flag
+    x->x_hasfeeders = else_magic_inlet_connection((t_object *)x, x->x_glist, 1, &s_signal); // magic feeder flag
     x->x_sr = sp[0]->s_sr;
     if (x->x_hasfeeders){
         dsp_add(imp_perform, 6, x, sp[0]->s_n,

--- a/Classes/Aliases/wt~.c
+++ b/Classes/Aliases/wt~.c
@@ -54,12 +54,12 @@ static t_int *wt_perform(t_int *w){
     t_word *vector = x->x_buffer->c_vectors[0];
     if(!x->x_hasfeeders){ // Magic
         t_float *scalar = x->x_signalscalar;
-        if(!magic_isnan(*x->x_signalscalar)){
+        if(!else_magic_isnan(*x->x_signalscalar)){
             t_float input_phase = fmod(*scalar, 1);
             if(input_phase < 0)
                 input_phase += 1;
             x->x_phase = input_phase;
-            magic_setnan(x->x_signalscalar);
+            else_magic_setnan(x->x_signalscalar);
         }
     }
     double phase = x->x_phase;
@@ -114,7 +114,7 @@ static t_int *wt_perform(t_int *w){
 
 static void wt_dsp(t_wt *x, t_signal **sp){
     buffer_checkdsp(x->x_buffer);
-    x->x_hasfeeders = inlet_connection((t_object *)x, x->x_glist, 1, &s_signal);
+    x->x_hasfeeders = else_magic_inlet_connection((t_object *)x, x->x_glist, 1, &s_signal);
     x->x_sr = sp[0]->s_sr;
     dsp_add(wt_perform, 6, x, sp[0]->s_n,
         sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, sp[3]->s_vec);

--- a/Classes/Source/brown~.c
+++ b/Classes/Source/brown~.c
@@ -63,7 +63,7 @@ static t_int *brown_perform(t_int *w){
 }
 
 static void brown_dsp(t_brown *x, t_signal **sp){
-    x->x_inmode = inlet_connection((t_object *)x, x->x_glist, 0, &s_signal);
+    x->x_inmode = else_magic_inlet_connection((t_object *)x, x->x_glist, 0, &s_signal);
     dsp_add(brown_perform, 4, x, sp[0]->s_n, sp[0]->s_vec, sp[1]->s_vec);
 }
 

--- a/Classes/Source/cosine~.c
+++ b/Classes/Source/cosine~.c
@@ -32,12 +32,12 @@ static t_int *cosine_perform(t_int *w){
     t_float *out = (t_float *)(w[6]);
     // Magic Start
     t_float *scalar = x->x_signalscalar;
-    if (!magic_isnan(*x->x_signalscalar)){
+    if (!else_magic_isnan(*x->x_signalscalar)){
         t_float input_phase = fmod(*scalar, 1);
         if (input_phase < 0)
             input_phase += 1;
         x->x_phase = input_phase;
-        magic_setnan(x->x_signalscalar);
+        else_magic_setnan(x->x_signalscalar);
     }
     // Magic End
     double phase = x->x_phase;
@@ -103,7 +103,7 @@ static t_int *cosine_perform_sig(t_int *w){
 }
 
 static void cosine_dsp(t_cosine *x, t_signal **sp){
-    x->x_hasfeeders = inlet_connection((t_object *)x, x->x_glist, 1, &s_signal); // magic feeder flag
+    x->x_hasfeeders = else_magic_inlet_connection((t_object *)x, x->x_glist, 1, &s_signal); // magic feeder flag
     x->x_sr = sp[0]->s_sr;
     if (x->x_hasfeeders){
         dsp_add(cosine_perform_sig, 6, x, sp[0]->s_n,

--- a/Classes/Source/fbsine~.c
+++ b/Classes/Source/fbsine~.c
@@ -44,12 +44,12 @@ static t_int *fbsine_perform_magic(t_int *w)
     t_float *out = (t_float *)(w[7]);
 // Magic Start
     t_float *scalar = x->x_signalscalar;
-    if (!magic_isnan(*x->x_signalscalar)){
+    if (!else_magic_isnan(*x->x_signalscalar)){
         t_float input_phase = fmod(*scalar, 1);
         if (input_phase < 0)
             input_phase += 1;
         x->x_phase = input_phase;
-        magic_setnan(x->x_signalscalar);
+        else_magic_setnan(x->x_signalscalar);
     }
 // Magic End
     float yn_m1 = x->x_yn_m1;
@@ -128,7 +128,7 @@ static t_int *fbsine_perform(t_int *w){
 }
 
 static void fbsine_dsp(t_fbsine *x, t_signal **sp){
-    x->x_hasfeeders = inlet_connection((t_object *)x, x->x_glist, 2, &s_signal); // magic feeder flag
+    x->x_hasfeeders = else_magic_inlet_connection((t_object *)x, x->x_glist, 2, &s_signal); // magic feeder flag
     x->x_sr = sp[0]->s_sr;
     if (x->x_hasfeeders){
         dsp_add(fbsine_perform, 7, x, sp[0]->s_n,

--- a/Classes/Source/gaussian~.c
+++ b/Classes/Source/gaussian~.c
@@ -32,12 +32,12 @@ static t_int *gaussian_perform_magic(t_int *w){
     t_float *out = (t_float *)(w[7]);
 // Magic Start
     t_float *scalar = x->x_signalscalar;
-    if(!magic_isnan(*x->x_signalscalar)){
+    if(!else_magic_isnan(*x->x_signalscalar)){
         t_float input_phase = fmod(*scalar, 1);
         if(input_phase < 0)
             input_phase += 1;
         x->x_phase = input_phase;
-        magic_setnan(x->x_signalscalar);
+        else_magic_setnan(x->x_signalscalar);
     }
 // Magic End
     double phase = x->x_phase;
@@ -117,7 +117,7 @@ static t_int *gaussian_perform(t_int *w)
 }
 
 static void gaussian_dsp(t_gaussian *x, t_signal **sp){
-    x->x_hasfeeders = inlet_connection((t_object *)x, x->x_glist, 2, &s_signal); // magic feeder flag
+    x->x_hasfeeders = else_magic_inlet_connection((t_object *)x, x->x_glist, 2, &s_signal); // magic feeder flag
     x->x_sr = sp[0]->s_sr;
     if (x->x_hasfeeders){
         dsp_add(gaussian_perform, 7, x, sp[0]->s_n,

--- a/Classes/Source/impulse2~.c
+++ b/Classes/Source/impulse2~.c
@@ -169,7 +169,7 @@ static t_int *impulse2_perform(t_int *w){
 
 
 static void impulse2_dsp(t_impulse2 *x, t_signal **sp){
-    x->x_hasfeeders = inlet_connection((t_object *)x, x->x_glist, 2, &s_signal); // magic feeder flag
+    x->x_hasfeeders = else_magic_inlet_connection((t_object *)x, x->x_glist, 2, &s_signal); // magic feeder flag
     x->x_sr = sp[0]->s_sr;
     if (x->x_hasfeeders){
         dsp_add(impulse2_perform, 7, x, sp[0]->s_n,

--- a/Classes/Source/impulse~.c
+++ b/Classes/Source/impulse~.c
@@ -33,14 +33,14 @@ static t_int *imp_perform_magic(t_int *w){
 // Magic Start
     int posfreq = x->x_posfreq;
     t_float *scalar = x->x_signalscalar;
-    if (!magic_isnan(*x->x_signalscalar)){
+    if (!else_magic_isnan(*x->x_signalscalar)){
         t_float input_phase = fmod(*scalar, 1);
         if (input_phase < 0)
             input_phase += 1;
         if(input_phase == 0 && x->x_posfreq)
             input_phase = 1;
         x->x_phase = input_phase;
-        magic_setnan(x->x_signalscalar);
+        else_magic_setnan(x->x_signalscalar);
     }
 // Magic End
     double phase = x->x_phase;
@@ -135,7 +135,7 @@ static t_int *imp_perform(t_int *w){
 }
 
 static void imp_dsp(t_imp *x, t_signal **sp){
-    x->x_hasfeeders = inlet_connection((t_object *)x, x->x_glist, 1, &s_signal); // magic feeder flag
+    x->x_hasfeeders = else_magic_inlet_connection((t_object *)x, x->x_glist, 1, &s_signal); // magic feeder flag
     x->x_sr = sp[0]->s_sr;
     if (x->x_hasfeeders){
         dsp_add(imp_perform, 6, x, sp[0]->s_n,

--- a/Classes/Source/lb.c
+++ b/Classes/Source/lb.c
@@ -113,5 +113,5 @@ void loadbanger_setup(void){
     class_addmethod(loadbanger_class, (t_method)loadbanger_loadbang, gensym("loadbang"), A_DEFFLOAT, 0);
     class_addmethod(loadbanger_class, (t_method)loadbanger_click, gensym("click"),
         A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT, A_FLOAT,0);
-    class_sethelpsymbol(f2s_class, gensym("loadbanger"));
+    //class_sethelpsymbol(f2s_class, gensym("loadbanger"));
 }

--- a/Classes/Source/midi.c
+++ b/Classes/Source/midi.c
@@ -127,7 +127,7 @@ static void midi_panic(t_midi *x){
    default value (failure).
    Upon return *nrequested contains the actual number of elements:
    requested (success) or a given default value of 'inisize' (failure). */
-void *grow_nodata(int *nrequested, int *sizep, void *bufp,
+static void *grow_nodata(int *nrequested, int *sizep, void *bufp,
 int inisize, void *bufini, size_t typesize){
     int newsize = *sizep * 2;
     while(newsize < *nrequested)
@@ -147,7 +147,7 @@ int inisize, void *bufini, size_t typesize){
 }
 
 /* Like grow_nodata(), but preserving first *nexisting elements. */
-void *grow_withdata(int *nrequested, int *nexisting, int *sizep, void *bufp,
+static void *grow_withdata(int *nrequested, int *nexisting, int *sizep, void *bufp,
 int inisize, void *bufini, size_t typesize){
     int newsize = *sizep * 2;
     while(newsize < *nrequested)
@@ -733,7 +733,7 @@ mfreadfailed:
 }
 
 static void midi_click(t_midi *x){
-    panel_click_open(x->x_elsefilehandle);
+    elsefile_panel_click_open(x->x_elsefilehandle);
 }
 
 static int midi_mfwrite(t_midi *x, char *path){
@@ -812,7 +812,7 @@ static void midi_textread(t_midi *x, char *path){
     t_binbuf *bb;
     bb = binbuf_new();
     if(binbuf_read(bb, path, "", 0)) // CHECKED no complaint, open dialog presented
-        panel_click_open(x->x_elsefilehandle);  // LATER rethink
+        elsefile_panel_click_open(x->x_elsefilehandle);  // LATER rethink
     else{
         int nlines = /* CHECKED absolute timestamps */
             midi_fromatoms(x, binbuf_getnatom(bb), binbuf_getvec(bb));
@@ -908,14 +908,14 @@ static void midi_read(t_midi *x, t_symbol *s){
     if(s && s != &s_)
         midi_doread(x, s);
     else
-        panel_click_open(x->x_elsefilehandle);
+        elsefile_panel_click_open(x->x_elsefilehandle);
 }
 
 static void midi_write(t_midi *x, t_symbol *s){
     if(s && s != &s_)
         midi_dowrite(x, s);
     else  // creation arg is a default elsefile name
-        panel_save(x->x_elsefilehandle, canvas_getdir(x->x_canvas), x->x_defname); // always start in canvas dir
+        elsefile_panel_save(x->x_elsefilehandle, canvas_getdir(x->x_canvas), x->x_defname); // always start in canvas dir
 }
 
 static void midi_free(t_midi *x){

--- a/Classes/Source/note.c
+++ b/Classes/Source/note.c
@@ -15,9 +15,9 @@
 #define NOTE_OUTBUFSIZE    16384
 
 #if __APPLE__
-char default_font[100] = "Menlo";
+static char default_font[100] = "Menlo";
 #else
-char default_font[100] = "DejaVu Sans Mono";
+static char default_font[100] = "DejaVu Sans Mono";
 #endif
 
 static t_class *note_class, *notesink_class, *handle_class, *edit_proxy_class;

--- a/Classes/Source/numbox~.c
+++ b/Classes/Source/numbox~.c
@@ -397,7 +397,7 @@ static t_int *numbox_perform(t_int *w){
 }
 
 static void numbox_dsp(t_numbox *x, t_signal **sp){
-    x->x_outmode = !inlet_connection((t_object *)x, x->x_glist, 0, &s_signal);
+    x->x_outmode = !else_magic_inlet_connection((t_object *)x, x->x_glist, 0, &s_signal);
     x->x_sr_khz = sp[0]->s_sr * 0.001;
     dsp_add(numbox_perform, 4, x, sp[0]->s_vec, sp[1]->s_vec, (t_int)sp[0]->s_n);
 }

--- a/Classes/Source/oscope~.c
+++ b/Classes/Source/oscope~.c
@@ -755,8 +755,8 @@ static t_int *scope_perform(t_int *w){
 
 static void scope_dsp(t_scope *x, t_signal **sp){
     x->x_ksr = sp[0]->s_sr * 0.001;
-    int xfeeder = inlet_connection((t_object *)x, x->x_glist, 0, &s_signal);
-    int yfeeder = inlet_connection((t_object *)x, x->x_glist, 1, &s_signal);
+    int xfeeder = else_magic_inlet_connection((t_object *)x, x->x_glist, 0, &s_signal);
+    int yfeeder = else_magic_inlet_connection((t_object *)x, x->x_glist, 1, &s_signal);
     int xymode = xfeeder + 2 * yfeeder;
     if(xymode != x->x_xymode){
         x->x_xymode = xymode;

--- a/Classes/Source/parabolic~.c
+++ b/Classes/Source/parabolic~.c
@@ -31,12 +31,12 @@ static t_int *parabolic_perform(t_int *w){
     t_float *out = (t_float *)(w[6]);
 // Magic Start
     t_float *scalar = x->x_signalscalar;
-    if (!magic_isnan(*x->x_signalscalar)){
+    if (!else_magic_isnan(*x->x_signalscalar)){
         t_float input_phase = fmod(*scalar, 1);
         if (input_phase < 0)
             input_phase += 1;
         x->x_phase = input_phase;
-        magic_setnan(x->x_signalscalar);
+        else_magic_setnan(x->x_signalscalar);
         }
 // Magic End
     double phase = x->x_phase;
@@ -103,7 +103,7 @@ static t_int *parabolic_perform_sig(t_int *w)
 }
 
 static void parabolic_dsp(t_parabolic *x, t_signal **sp){
-    x->x_hasfeeders = inlet_connection((t_object *)x, x->x_glist, 1, &s_signal); // magic feeder flag
+    x->x_hasfeeders = else_magic_inlet_connection((t_object *)x, x->x_glist, 1, &s_signal); // magic feeder flag
     x->x_sr = sp[0]->s_sr;
     if (x->x_hasfeeders){
         dsp_add(parabolic_perform_sig, 6, x, sp[0]->s_n,

--- a/Classes/Source/pimp~.c
+++ b/Classes/Source/pimp~.c
@@ -34,14 +34,14 @@ static t_int *pimp_perform_magic(t_int *w){
     int posfreq = x->x_posfreq;
 // Magic Start
     t_float *scalar = x->x_signalscalar;
-    if(!magic_isnan(*x->x_signalscalar)){
+    if(!else_magic_isnan(*x->x_signalscalar)){
         t_float input_phase = fmod(*scalar, 1);
         if(input_phase < 0)
             input_phase += 1;
 /*        if(input_phase == 0 && x->x_posfreq)
             input_phase = 1;*/
         x->x_phase = input_phase;
-        magic_setnan(x->x_signalscalar);
+        else_magic_setnan(x->x_signalscalar);
     }
 // Magic End 
     double phase = x->x_phase;
@@ -139,7 +139,7 @@ static t_int *pimp_perform(t_int *w){
 }
 
 static void pimp_dsp(t_pimp *x, t_signal **sp){
-    x->x_hasfeeders = inlet_connection((t_object *)x, x->x_glist, 1, &s_signal); // magic feeder flag
+    x->x_hasfeeders = else_magic_inlet_connection((t_object *)x, x->x_glist, 1, &s_signal); // magic feeder flag
     x->x_sr = sp[0]->s_sr;
     if(x->x_hasfeeders){
         dsp_add(pimp_perform, 7, x, sp[0]->s_n,

--- a/Classes/Source/pulse~.c
+++ b/Classes/Source/pulse~.c
@@ -36,12 +36,12 @@ static t_int *pulse_perform_magic(t_int *w)
     t_float *out = (t_float *)(w[7]);
 // Magic Start
     t_float *scalar = x->x_signalscalar;
-    if (!magic_isnan(*x->x_signalscalar)){
+    if (!else_magic_isnan(*x->x_signalscalar)){
         t_float input_phase = fmod(*scalar, 1);
         if (input_phase < 0)
             input_phase += 1;
         x->x_phase = input_phase;
-        magic_setnan(x->x_signalscalar);
+        else_magic_setnan(x->x_signalscalar);
     }
 // Magic End
     double phase = x->x_phase;
@@ -169,7 +169,7 @@ static t_int *pulse_perform(t_int *w)
 }
 
 static void pulse_dsp(t_pulse *x, t_signal **sp){
-    x->x_hasfeeders = inlet_connection((t_object *)x, x->x_glist, 2, &s_signal); // magic feeder flag
+    x->x_hasfeeders = else_magic_inlet_connection((t_object *)x, x->x_glist, 2, &s_signal); // magic feeder flag
     x->x_sr = sp[0]->s_sr;
     if (x->x_hasfeeders){
         dsp_add(pulse_perform, 7, x, sp[0]->s_n,

--- a/Classes/Source/rec.c
+++ b/Classes/Source/rec.c
@@ -412,7 +412,7 @@ static void rec_doread(t_rec *x, t_symbol *fname){
         binbuf_free(bb);
     }
     else
-        panel_click_open(x->x_elsefilehandle);
+        elsefile_panel_click_open(x->x_elsefilehandle);
 }
 
 static int rec_writetrack(t_rec *x, t_rec_track *tp, FILE *fp){
@@ -511,18 +511,18 @@ static void rec_read(t_rec *x, t_symbol *s){
     if(s && s != &s_)
         rec_doread(x, s);
     else
-        panel_click_open(x->x_elsefilehandle);
+        elsefile_panel_click_open(x->x_elsefilehandle);
 }
 
 static void rec_write(t_rec *x, t_symbol *s){
     if(s && s != &s_)
         rec_dowrite(x, s);
     else
-        panel_save(x->x_elsefilehandle, canvas_getdir(x->x_canvas), 0);
+        elsefile_panel_save(x->x_elsefilehandle, canvas_getdir(x->x_canvas), 0);
 }
 
 static void rec_click(t_rec *x){
-    panel_click_open(x->x_elsefilehandle);
+    elsefile_panel_click_open(x->x_elsefilehandle);
 }
 
 static void rec_free(t_rec *x){

--- a/Classes/Source/saw2~.c
+++ b/Classes/Source/saw2~.c
@@ -31,12 +31,12 @@ static t_int *saw2_perform(t_int *w){
     t_float *out = (t_float *)(w[6]);
 // Magic Start
     t_float *scalar = x->x_signalscalar;
-    if (!magic_isnan(*x->x_signalscalar)){
+    if (!else_magic_isnan(*x->x_signalscalar)){
         t_float input_phase = fmod(*scalar, 1);
         if (input_phase < 0)
             input_phase += 1;
         x->x_phase = input_phase;
-        magic_setnan(x->x_signalscalar);
+        else_magic_setnan(x->x_signalscalar);
         }
 // Magic End
     double phase = x->x_phase;
@@ -111,7 +111,7 @@ static t_int *saw2_perform_sig(t_int *w)
 }
 
 static void saw2_dsp(t_saw2 *x, t_signal **sp){
-    x->x_hasfeeders = inlet_connection((t_object *)x, x->x_glist, 1, &s_signal); // magic feeder flag
+    x->x_hasfeeders = else_magic_inlet_connection((t_object *)x, x->x_glist, 1, &s_signal); // magic feeder flag
     x->x_sr = sp[0]->s_sr;
     if (x->x_hasfeeders){
         dsp_add(saw2_perform_sig, 6, x, sp[0]->s_n,

--- a/Classes/Source/saw~.c
+++ b/Classes/Source/saw~.c
@@ -31,12 +31,12 @@ static t_int *saw_perform(t_int *w){
     t_float *out = (t_float *)(w[6]);
 // Magic Start
     t_float *scalar = x->x_signalscalar;
-    if (!magic_isnan(*x->x_signalscalar)){
+    if (!else_magic_isnan(*x->x_signalscalar)){
         t_float input_phase = fmod(*scalar, 1);
         if (input_phase < 0)
             input_phase += 1;
         x->x_phase = input_phase;
-        magic_setnan(x->x_signalscalar);
+        else_magic_setnan(x->x_signalscalar);
         }
 // Magic End
     double phase = x->x_phase;
@@ -103,7 +103,7 @@ static t_int *saw_perform_sig(t_int *w)
 }
 
 static void saw_dsp(t_saw *x, t_signal **sp){
-    x->x_hasfeeders = inlet_connection((t_object *)x, x->x_glist, 1, &s_signal); // magic feeder flag
+    x->x_hasfeeders = else_magic_inlet_connection((t_object *)x, x->x_glist, 1, &s_signal); // magic feeder flag
     x->x_sr = sp[0]->s_sr;
     if (x->x_hasfeeders){
         dsp_add(saw_perform_sig, 6, x, sp[0]->s_n,

--- a/Classes/Source/sine~.c
+++ b/Classes/Source/sine~.c
@@ -32,12 +32,12 @@ static t_int *sine_perform(t_int *w){
     t_float *out = (t_float *)(w[6]);
 // Magic Start
     t_float *scalar = x->x_signalscalar;
-    if(!magic_isnan(*x->x_signalscalar)){
+    if(!else_magic_isnan(*x->x_signalscalar)){
         t_float input_phase = fmod(*scalar, 1);
         if(input_phase < 0)
             input_phase += 1;
         x->x_phase = input_phase;
-        magic_setnan(x->x_signalscalar);
+        else_magic_setnan(x->x_signalscalar);
     }
 // Magic End
     double phase = x->x_phase;
@@ -103,7 +103,7 @@ static t_int *sine_perform_sig(t_int *w){
 }
 
 static void sine_dsp(t_sine *x, t_signal **sp){
-    x->x_hasfeeders = inlet_connection((t_object *)x, x->x_glist, 1, &s_signal); // magic feeder flag
+    x->x_hasfeeders = else_magic_inlet_connection((t_object *)x, x->x_glist, 1, &s_signal); // magic feeder flag
     x->x_sr = sp[0]->s_sr;
     if(x->x_hasfeeders){
         dsp_add(sine_perform_sig, 6, x, sp[0]->s_n,

--- a/Classes/Source/square~.c
+++ b/Classes/Source/square~.c
@@ -36,12 +36,12 @@ static t_int *square_perform_magic(t_int *w)
     t_float *out = (t_float *)(w[7]);
 // Magic Start
     t_float *scalar = x->x_signalscalar;
-    if (!magic_isnan(*x->x_signalscalar)){
+    if (!else_magic_isnan(*x->x_signalscalar)){
         t_float input_phase = fmod(*scalar, 1);
         if (input_phase < 0)
             input_phase += 1;
         x->x_phase = input_phase;
-        magic_setnan(x->x_signalscalar);
+        else_magic_setnan(x->x_signalscalar);
     }
 // Magic End
     double phase = x->x_phase;
@@ -168,7 +168,7 @@ static t_int *square_perform(t_int *w)
 }
 
 static void square_dsp(t_square *x, t_signal **sp){
-    x->x_hasfeeders = inlet_connection((t_object *)x, x->x_glist, 2, &s_signal); // magic feeder flag
+    x->x_hasfeeders = else_magic_inlet_connection((t_object *)x, x->x_glist, 2, &s_signal); // magic feeder flag
     x->x_sr = sp[0]->s_sr;
     if (x->x_hasfeeders){
         dsp_add(square_perform, 7, x, sp[0]->s_n,

--- a/Classes/Source/tabplayer~.c
+++ b/Classes/Source/tabplayer~.c
@@ -447,7 +447,7 @@ static t_int *tabplayer_perform(t_int *w){
 static void tabplayer_dsp(t_play *x, t_signal **sp){
     buffer_checkdsp(x->x_buffer);
     unsigned long long npts = x->x_buffer->c_npts;
-    x->x_hasfeeders = inlet_connection((t_object *)x, x->x_glist, 0, &s_signal);
+    x->x_hasfeeders = else_magic_inlet_connection((t_object *)x, x->x_glist, 0, &s_signal);
     t_float pdksr = sp[0]->s_sr * 0.001;
     if(x->x_sr_khz != pdksr)
         x->x_sr_ratio = (double)(x->x_array_sr_khz/(x->x_sr_khz = pdksr));

--- a/Classes/Source/tri~.c
+++ b/Classes/Source/tri~.c
@@ -33,12 +33,12 @@ static t_int *tri_perform(t_int *w){
     t_float *out = (t_float *)(w[6]);
 // Magic Start
     t_float *scalar = x->x_signalscalar;
-    if (!magic_isnan(*x->x_signalscalar)){
+    if (!else_magic_isnan(*x->x_signalscalar)){
         t_float input_phase = fmod(*scalar, 1);
         if (input_phase < 0)
             input_phase += 1;
         x->x_phase = input_phase;
-        magic_setnan(x->x_signalscalar);
+        else_magic_setnan(x->x_signalscalar);
         }
 // Magic End
     double phase = x->x_phase;
@@ -117,7 +117,7 @@ static t_int *tri_perform_sig(t_int *w)
 }
 
 static void tri_dsp(t_tri *x, t_signal **sp){
-    x->x_hasfeeders = inlet_connection((t_object *)x, x->x_glist, 1, &s_signal); // magic feeder flag
+    x->x_hasfeeders = else_magic_inlet_connection((t_object *)x, x->x_glist, 1, &s_signal); // magic feeder flag
     x->x_sr = sp[0]->s_sr;
     if (x->x_hasfeeders){
         dsp_add(tri_perform_sig, 6, x, sp[0]->s_n,

--- a/Classes/Source/vsaw~.c
+++ b/Classes/Source/vsaw~.c
@@ -34,12 +34,12 @@ static t_int *vsaw_perform_magic(t_int *w)
     t_float *out = (t_float *)(w[7]);
 // Magic Start
     t_float *scalar = x->x_signalscalar;
-    if (!magic_isnan(*x->x_signalscalar)){
+    if (!else_magic_isnan(*x->x_signalscalar)){
         t_float input_phase = fmod(*scalar, 1);
         if (input_phase < 0)
             input_phase += 1;
         x->x_phase = input_phase;
-        magic_setnan(x->x_signalscalar);
+        else_magic_setnan(x->x_signalscalar);
     }
 // Magic End
     double phase = x->x_phase;
@@ -138,7 +138,7 @@ static t_int *vsaw_perform(t_int *w)
 }
 
 static void vsaw_dsp(t_vsaw *x, t_signal **sp){
-    x->x_hasfeeders = inlet_connection((t_object *)x, x->x_glist, 2, &s_signal); // magic feeder flag
+    x->x_hasfeeders = else_magic_inlet_connection((t_object *)x, x->x_glist, 2, &s_signal); // magic feeder flag
     x->x_sr = sp[0]->s_sr;
     if (x->x_hasfeeders){
         dsp_add(vsaw_perform, 7, x, sp[0]->s_n,

--- a/Classes/Source/wavetable~.c
+++ b/Classes/Source/wavetable~.c
@@ -54,12 +54,12 @@ static t_int *wavetable_perform(t_int *w){
     t_word *vector = x->x_buffer->c_vectors[0];
     if(!x->x_hasfeeders){ // Magic
         t_float *scalar = x->x_signalscalar;
-        if(!magic_isnan(*x->x_signalscalar)){
+        if(!else_magic_isnan(*x->x_signalscalar)){
             t_float input_phase = fmod(*scalar, 1);
             if(input_phase < 0)
                 input_phase += 1;
             x->x_phase = input_phase;
-            magic_setnan(x->x_signalscalar);
+            else_magic_setnan(x->x_signalscalar);
         }
     }
     double phase = x->x_phase;
@@ -114,7 +114,7 @@ static t_int *wavetable_perform(t_int *w){
 
 static void wavetable_dsp(t_wavetable *x, t_signal **sp){
     buffer_checkdsp(x->x_buffer);
-    x->x_hasfeeders = inlet_connection((t_object *)x, x->x_glist, 1, &s_signal);
+    x->x_hasfeeders = else_magic_inlet_connection((t_object *)x, x->x_glist, 1, &s_signal);
     x->x_sr = sp[0]->s_sr;
     dsp_add(wavetable_perform, 6, x, sp[0]->s_n,
         sp[0]->s_vec, sp[1]->s_vec, sp[2]->s_vec, sp[3]->s_vec);

--- a/shared/elsefile.c
+++ b/shared/elsefile.c
@@ -5,6 +5,7 @@
 #else
 #include <unistd.h>
 #include <dirent.h>
+#include <stdlib.h>
 #endif
 
 #include "m_pd.h"
@@ -16,7 +17,7 @@
 // OS
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-static int ospath_doabsolute(char *path, char *cwd, char *result){
+static int elsefile_ospath_doabsolute(char *path, char *cwd, char *result){
     if(*path == 0){
         if(result)
             strcpy(result, cwd);
@@ -165,16 +166,16 @@ badpath:
  superfluous slashes and dots), but not longer.  Both args should be unbashed
  (system-independent), cwd should be absolute.  Returns 0 in case of any
  error (LATER revisit). */
-int ospath_length(char *path, char *cwd){ // one extra byte used internally (guarding slash)
-    return(ospath_doabsolute(path, cwd, 0) + 1);
+int elsefile_ospath_length(char *path, char *cwd){ // one extra byte used internally (guarding slash)
+    return(elsefile_ospath_doabsolute(path, cwd, 0) + 1);
 }
 
 /* Copies an absolute path to result.  Arguments: path and cwd, are the same
  as in ospath_length().  Caller should first consult ospath_length(), and
  allocate at least ospath_length() + 1 bytes to the result buffer.
  Should never fail (failure is a bug). */
-char *ospath_absolute(char *path, char *cwd, char *result){
-    ospath_doabsolute(path, cwd, result);
+char *elsefile_ospath_absolute(char *path, char *cwd, char *result){
+    elsefile_ospath_doabsolute(path, cwd, result);
     return(result);
 }
 
@@ -190,7 +191,7 @@ struct _osdir{
 
 /* returns 0 on error, a caller is then expected to call
  loud_syserror(owner, "cannot open \"%s\"", dirname) */
-t_osdir *osdir_open(char *dirname){
+t_osdir *elsefile_osdir_open(char *dirname){
 #ifndef _WIN32
     DIR *handle = opendir(dirname);
     if(handle){
@@ -209,12 +210,12 @@ t_osdir *osdir_open(char *dirname){
 #endif
 }
 
-void osdir_setmode(t_osdir *dp, int flags){
+void elsefile_osdir_setmode(t_osdir *dp, int flags){
     if(dp)
         dp->dir_flags = flags;
 }
 
-void osdir_close(t_osdir *dp){
+void elsefile_osdir_close(t_osdir *dp){
     if(dp){
 #ifndef _WIN32
         closedir(dp->dir_handle);
@@ -223,7 +224,7 @@ void osdir_close(t_osdir *dp){
     }
 }
 
-void osdir_rewind(t_osdir *dp){
+void elsefile_osdir_rewind(t_osdir *dp){
     if(dp){
 #ifndef _WIN32
         rewinddir(dp->dir_handle);
@@ -232,7 +233,7 @@ void osdir_rewind(t_osdir *dp){
     }
 }
 
-char *osdir_next(t_osdir *dp){
+char *elsefile_osdir_next(t_osdir *dp){
 #ifndef _WIN32
     if(dp){
         while((dp->dir_entry = readdir(dp->dir_handle))){
@@ -247,7 +248,7 @@ char *osdir_next(t_osdir *dp){
     return(0);
 }
 
-int osdir_isfile(t_osdir *dp){
+int elsefile_osdir_isfile(t_osdir *dp){
 #ifndef _WIN32
     return(dp && dp->dir_entry && dp->dir_entry->d_type == DT_REG);
 #else
@@ -255,7 +256,7 @@ int osdir_isfile(t_osdir *dp){
 #endif
 }
 
-int osdir_isdir(t_osdir *dp){
+int elsefile_osdir_isdir(t_osdir *dp){
 #ifndef _WIN32
     return(dp && dp->dir_entry && dp->dir_entry->d_type == DT_DIR);
 #else
@@ -331,19 +332,19 @@ static void panel_guidefs(void){
 
 /* This is obsolete, but has to stay, because older versions of miXed libraries
    might overwrite new panel_guidefs().  FIXME we need version control. */
-static void panel_symbol(t_elsefile *f, t_symbol *s){
+static void elsefile_panel_symbol(t_elsefile *f, t_symbol *s){
     if(s && s != &s_ && f->f_panelfn)
         (*f->f_panelfn)(f->f_master, s, 0, 0);
 }
 
-static void panel_path(t_elsefile *f, t_symbol *s1, t_symbol *s2){
+static void elsefile_panel_path(t_elsefile *f, t_symbol *s1, t_symbol *s2){
     if(s2 && s2 != &s_)
         f->f_currentdir = s2;
     if(s1 && s1 != &s_ && f->f_panelfn)
         (*f->f_panelfn)(f->f_master, s1, 0, 0);
 }
 
-static void panel_tick(t_elsefile *f){
+static void elsefile_panel_tick(t_elsefile *f){
     if(f->f_savepanel)
         sys_vgui("panel_open %s {%s}\n", f->f_bindname->s_name, f->f_inidir->s_name);
     else
@@ -352,18 +353,18 @@ static void panel_tick(t_elsefile *f){
 
 /* these are hacks: deferring modal dialog creation in order to allow for
    a message box redraw to happen -- LATER investigate */
-void panel_click_open(t_elsefile *f){
+void elsefile_panel_click_open(t_elsefile *f){
     f->f_inidir = (f->f_currentdir ? f->f_currentdir : &s_);
     clock_delay(f->f_panelclock, 0);
 }
 
-void panel_setopendir(t_elsefile *f, t_symbol *dir){
+void elsefile_panel_setopendir(t_elsefile *f, t_symbol *dir){
     if(f->f_currentdir && f->f_currentdir != &s_){
         if(dir && dir != &s_){
-            int length = ospath_length((char *)(dir->s_name), (char *)(f->f_currentdir->s_name));
+            int length = elsefile_ospath_length((char *)(dir->s_name), (char *)(f->f_currentdir->s_name));
             if(length){
                 char *path = getbytes(length + 1);
-                if(ospath_absolute((char *)(dir->s_name), (char *)(f->f_currentdir->s_name), path))
+                if(elsefile_ospath_absolute((char *)(dir->s_name), (char *)(f->f_currentdir->s_name), path))
                 /* LATER stat (think how to report a failure) */
                     f->f_currentdir = gensym(path);
                 freebytes(path, length + 1);
@@ -376,11 +377,11 @@ void panel_setopendir(t_elsefile *f, t_symbol *dir){
         bug("panel_setopendir");
 }
 
-t_symbol *panel_getopendir(t_elsefile *f){
+t_symbol *elsefile_panel_getopendir(t_elsefile *f){
     return(f->f_currentdir);
 }
 
-void panel_save(t_elsefile *f, t_symbol *inidir, t_symbol *inifile){
+void elsefile_panel_save(t_elsefile *f, t_symbol *inidir, t_symbol *inifile){
     if((f = f->f_savepanel)){
         if(inidir)
             f->f_inidir = inidir;
@@ -392,12 +393,12 @@ void panel_save(t_elsefile *f, t_symbol *inidir, t_symbol *inifile){
     }
 }
 
-void panel_setsavedir(t_elsefile *f, t_symbol *dir){
+void elsefile_panel_setsavedir(t_elsefile *f, t_symbol *dir){
     if((f = f->f_savepanel))
-        panel_setopendir(f, dir);
+        elsefile_panel_setopendir(f, dir);
 }
 
-t_symbol *panel_getsavedir(t_elsefile *f){
+t_symbol *elsefile_panel_getsavedir(t_elsefile *f){
     return(f->f_savepanel ? f->f_savepanel->f_currentdir : 0);
 }
 
@@ -464,7 +465,7 @@ t_elsefile *elsefile_new(t_pd *master, t_elsefilefn readfn, t_elsefilefn writefn
         pd_bind((t_pd *)result, result->f_bindname);
         result->f_currentdir = result->f_inidir = canvas_getdir(result->f_canvas);
         result->f_panelfn = readfn;
-        result->f_panelclock = clock_new(result, (t_method)panel_tick);
+        result->f_panelclock = clock_new(result, (t_method)elsefile_panel_tick);
         f = (t_elsefile *)pd_new(elsefile_class);
         f->f_master = master;
         f->f_canvas = result->f_canvas;
@@ -473,7 +474,7 @@ t_elsefile *elsefile_new(t_pd *master, t_elsefilefn readfn, t_elsefilefn writefn
         pd_bind((t_pd *)f, f->f_bindname);
         f->f_currentdir = f->f_inidir = result->f_currentdir;
         f->f_panelfn = writefn;
-        f->f_panelclock = clock_new(f, (t_method)panel_tick);
+        f->f_panelclock = clock_new(f, (t_method)elsefile_panel_tick);
         result->f_savepanel = f;
     }
     else
@@ -485,8 +486,8 @@ void elsefile_setup(void){
     if(!elsefile_class){
         ps__C = gensym("#C");
         elsefile_class = class_new(gensym("_elsefile"), 0, 0,sizeof(t_elsefile), CLASS_PD | CLASS_NOINLET, 0);
-        class_addsymbol(elsefile_class, panel_symbol);
-        class_addmethod(elsefile_class, (t_method)panel_path,gensym("path"), A_SYMBOL, A_DEFSYM, 0);
+        class_addsymbol(elsefile_class, elsefile_panel_symbol);
+        class_addmethod(elsefile_class, (t_method)elsefile_panel_path,gensym("path"), A_SYMBOL, A_DEFSYM, 0);
         panel_guidefs();
     }
 }

--- a/shared/elsefile.h
+++ b/shared/elsefile.h
@@ -12,16 +12,16 @@ EXTERN_STRUCT _osdir;
 #define OSDIR_elsefileMODE  1
 #define OSDIR_DIRMODE   2
 
-int ospath_length(char *path, char *cwd);
-char *ospath_absolute(char *path, char *cwd, char *result);
+int elsefile_ospath_length(char *path, char *cwd);
+char *elsefile_ospath_absolute(char *path, char *cwd, char *result);
 
-t_osdir *osdir_open(char *dirname);
-void osdir_setmode(t_osdir *dp, int flags);
-void osdir_close(t_osdir *dp);
-void osdir_rewind(t_osdir *dp);
-char *osdir_next(t_osdir *dp);
-int osdir_isfile(t_osdir *dp);
-int osdir_isdir(t_osdir *dp);
+t_osdir *elsefile_osdir_open(char *dirname);
+void elsefile_osdir_setmode(t_osdir *dp, int flags);
+void elsefile_osdir_close(t_osdir *dp);
+void elsefile_osdir_rewind(t_osdir *dp);
+char *elsefile_osdir_next(t_osdir *dp);
+int elsefile_osdir_isfile(t_osdir *dp);
+int elsefile_osdir_isdir(t_osdir *dp);
 
 #endif
 
@@ -33,12 +33,12 @@ EXTERN_STRUCT _elsefile;
 
 typedef void (*t_elsefilefn)(t_pd *, t_symbol *, int, t_atom *);
 
-void panel_click_open(t_elsefile *f);
-void panel_setopendir(t_elsefile *f, t_symbol *dir);
-t_symbol *panel_getopendir(t_elsefile *f);
-void panel_save(t_elsefile *f, t_symbol *inidir, t_symbol *inifile);
-void panel_setsavedir(t_elsefile *f, t_symbol *dir);
-t_symbol *panel_getsavedir(t_elsefile *f);
+void elsefile_panel_click_open(t_elsefile *f);
+void elsefile_panel_setopendir(t_elsefile *f, t_symbol *dir);
+t_symbol *elsefile_panel_getopendir(t_elsefile *f);
+void elsefile_panel_save(t_elsefile *f, t_symbol *inidir, t_symbol *inifile);
+void elsefile_panel_setsavedir(t_elsefile *f, t_symbol *dir);
+t_symbol *elsefile_panel_getsavedir(t_elsefile *f);
 int elsefile_ismapped(t_elsefile *f);
 int elsefile_isloading(t_elsefile *f);
 int elsefile_ispasting(t_elsefile *f);

--- a/shared/magic.c
+++ b/shared/magic.c
@@ -5,7 +5,7 @@
 #include <g_canvas.h>
 #include <stdint.h>
 
-int inlet_connection(t_object *x, t_glist *glist, int inno, t_symbol *outsym){
+int else_magic_inlet_connection(t_object *x, t_glist *glist, int inno, t_symbol *outsym){
     t_linetraverser t;
     linetraverser_start(&t, glist);
     while(linetraverser_next(&t))
@@ -14,13 +14,13 @@ int inlet_connection(t_object *x, t_glist *glist, int inno, t_symbol *outsym){
     return(0);
 }
 
-void magic_setnan(t_float *in){
+void else_magic_setnan(t_float *in){
 	union magic_ui32_fl input_u;
 	input_u.uif_uint32 = MAGIC_NAN;
 	*in = input_u.uif_float;
 }
 
-int magic_isnan(t_float in){
+int else_magic_isnan(t_float in){
 	union magic_ui32_fl input_u;
 	input_u.uif_float = in;
 	return(((input_u.uif_uint32 & 0x7f800000ul) == 0x7f800000ul) && (input_u.uif_uint32 & 0x007fffff));

--- a/shared/magic.h
+++ b/shared/magic.h
@@ -7,6 +7,6 @@ union magic_ui32_fl{
 	t_float uif_float;
 };
 
-int inlet_connection(t_object *x, t_glist *glist, int inno, t_symbol *outsym);
-void magic_setnan (t_float *in);
-int magic_isnan (t_float in);
+int else_magic_inlet_connection(t_object *x, t_glist *glist, int inno, t_symbol *outsym);
+void else_magic_setnan (t_float *in);
+int else_magic_isnan (t_float in);


### PR DESCRIPTION
- else magic functions now have the else_magic_ prefix
- elsefile functions now have the prefix elsefile_
- Made some functions and variables with the same names static
- Added missing stdlib include to elsefile.c

This could also prevent some bugs when using cyclone and ELSE simultaneously in Pd-vanilla