### PR TITLE
Add installplus to the install requisites.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -363,6 +363,8 @@ README.pdf \
 PDLIBBUILDER_DIR=pd-lib-builder/
 include $(PDLIBBUILDER_DIR)/Makefile.pdlibbuilder
 
+install: installplus
+
 installplus: install 
 	cp -r ./folders/Live-Electronics-Tutorial "${installpath}"/Live-Electronics-Tutorial;
 	cp -r ./folders/pdlua "${installpath}"/pdlua;


### PR DESCRIPTION
This makes sure that with `make install` the `installplus` target is always run as well.

It's much too easy to forget this and then end up with a directory that doesn't contain the stuff from the folders subdir. Which means that the pdlua help patches appear to be broken. Happened to me. :)