### PR TITLE
Sfont compile fixes

### DIFF
--- a/sfont~/Makefile
+++ b/sfont~/Makefile
@@ -1,12 +1,18 @@
 
-cflags = -Ishared -DHAVE_STRUCT_TIMESPEC
+# Homebrew support (pdlib-builder assumes Fink)
+ifneq ($(HOMEBREW_PREFIX),)
+EXTRA_INCLUDES = -I$(HOMEBREW_PREFIX)/include
+EXTRA_LDFLAGS = -L$(HOMEBREW_PREFIX)/lib
+endif
+
+cflags = $(EXTRA_INCLUDES) -Ishared -DHAVE_STRUCT_TIMESPEC
 
 lib.name = sfont~
 
 file := ../shared/elsefile.c 
 sfont~.class.sources := sfont~.c $(file)
 
-ldlibs = -lfluidsynth
+ldlibs = $(EXTRA_LDFLAGS) -lfluidsynth
 
 datafiles = sfont~-help.pd
 datadirs = sf

--- a/sfont~/sfont~.c
+++ b/sfont~/sfont~.c
@@ -531,14 +531,14 @@ static void sfont_readhook(t_pd *z, t_symbol *fn, int ac, t_atom *av){
 }
 
 static void sfont_click(t_sfont *x){
-    panel_click_open(x->x_elsefilehandle);
+    elsefile_panel_click_open(x->x_elsefilehandle);
 }
 
 static void sfont_open(t_sfont *x, t_symbol *s){
     if(s && s != &s_)
         fluid_do_load(x, s);
     else
-        panel_click_open(x->x_elsefilehandle);
+        elsefile_panel_click_open(x->x_elsefilehandle);
 }
 
 t_int *sfont_perform(t_int *w){


### PR DESCRIPTION
sfont~.c compilation was broken due to a recent source change in shared/elsefile. Also added an auto-detection for Homebrew in the Makefile. (pd-lib-builder just always assumes Fink, but many people, myself included, use Homebrew these days.)