### PR TITLE
Sfont compile fixes again

### DIFF
--- a/Classes/Source/midi.c
+++ b/Classes/Source/midi.c
@@ -733,7 +733,7 @@ mfreadfailed:
 }
 
 static void midi_click(t_midi *x){
-    panel_click_open(x->x_elsefilehandle);
+    elsefile_panel_click_open(x->x_elsefilehandle);
 }
 
 static int midi_mfwrite(t_midi *x, char *path){
@@ -812,7 +812,7 @@ static void midi_textread(t_midi *x, char *path){
     t_binbuf *bb;
     bb = binbuf_new();
     if(binbuf_read(bb, path, "", 0)) // CHECKED no complaint, open dialog presented
-        panel_click_open(x->x_elsefilehandle);  // LATER rethink
+        elsefile_panel_click_open(x->x_elsefilehandle);  // LATER rethink
     else{
         int nlines = /* CHECKED absolute timestamps */
             midi_fromatoms(x, binbuf_getnatom(bb), binbuf_getvec(bb));
@@ -908,7 +908,7 @@ static void midi_read(t_midi *x, t_symbol *s){
     if(s && s != &s_)
         midi_doread(x, s);
     else
-        panel_click_open(x->x_elsefilehandle);
+        elsefile_panel_click_open(x->x_elsefilehandle);
 }
 
 static void midi_write(t_midi *x, t_symbol *s){

--- a/Classes/Source/midi.c
+++ b/Classes/Source/midi.c
@@ -915,7 +915,7 @@ static void midi_write(t_midi *x, t_symbol *s){
     if(s && s != &s_)
         midi_dowrite(x, s);
     else  // creation arg is a default elsefile name
-        panel_save(x->x_elsefilehandle, canvas_getdir(x->x_canvas), x->x_defname); // always start in canvas dir
+        elsefile_panel_save(x->x_elsefilehandle, canvas_getdir(x->x_canvas), x->x_defname); // always start in canvas dir
 }
 
 static void midi_free(t_midi *x){

--- a/Classes/Source/rec.c
+++ b/Classes/Source/rec.c
@@ -412,7 +412,7 @@ static void rec_doread(t_rec *x, t_symbol *fname){
         binbuf_free(bb);
     }
     else
-        panel_click_open(x->x_elsefilehandle);
+        elsefile_panel_click_open(x->x_elsefilehandle);
 }
 
 static int rec_writetrack(t_rec *x, t_rec_track *tp, FILE *fp){
@@ -511,7 +511,7 @@ static void rec_read(t_rec *x, t_symbol *s){
     if(s && s != &s_)
         rec_doread(x, s);
     else
-        panel_click_open(x->x_elsefilehandle);
+        elsefile_panel_click_open(x->x_elsefilehandle);
 }
 
 static void rec_write(t_rec *x, t_symbol *s){
@@ -522,7 +522,7 @@ static void rec_write(t_rec *x, t_symbol *s){
 }
 
 static void rec_click(t_rec *x){
-    panel_click_open(x->x_elsefilehandle);
+    elsefile_panel_click_open(x->x_elsefilehandle);
 }
 
 static void rec_free(t_rec *x){

--- a/Classes/Source/rec.c
+++ b/Classes/Source/rec.c
@@ -518,7 +518,7 @@ static void rec_write(t_rec *x, t_symbol *s){
     if(s && s != &s_)
         rec_dowrite(x, s);
     else
-        panel_save(x->x_elsefilehandle, canvas_getdir(x->x_canvas), 0);
+        elsefile_panel_save(x->x_elsefilehandle, canvas_getdir(x->x_canvas), 0);
 }
 
 static void rec_click(t_rec *x){

--- a/sfont~/Makefile
+++ b/sfont~/Makefile
@@ -1,11 +1,5 @@
 
-# Homebrew support (pdlib-builder assumes Fink)
-ifneq ($(HOMEBREW_PREFIX),)
-EXTRA_INCLUDES = -I$(HOMEBREW_PREFIX)/include
-EXTRA_LDFLAGS = -L$(HOMEBREW_PREFIX)/lib
-endif
-
-cflags = $(EXTRA_INCLUDES) -Ishared -DHAVE_STRUCT_TIMESPEC
+cflags = -Ishared -DHAVE_STRUCT_TIMESPEC
 
 lib.name = sfont~
 

--- a/sfont~/Makefile
+++ b/sfont~/Makefile
@@ -1,12 +1,18 @@
 
-cflags = -Ishared -DHAVE_STRUCT_TIMESPEC
+# Homebrew support (pdlib-builder assumes Fink)
+ifneq ($(HOMEBREW_PREFIX),)
+EXTRA_INCLUDES = -I$(HOMEBREW_PREFIX)/include
+EXTRA_LDFLAGS = -L$(HOMEBREW_PREFIX)/lib
+endif
+
+cflags = $(EXTRA_INCLUDES) -Ishared -DHAVE_STRUCT_TIMESPEC
 
 lib.name = sfont~
 
 file := ../shared/elsefile.c 
 sfont~.class.sources := sfont~.c $(file)
 
-ldlibs = -lfluidsynth
+ldlibs = $(EXTRA_LDFLAGS) -lfluidsynth
 
 datafiles = sfont~-help.pd
 datadirs = sf

--- a/sfont~/sfont~.c
+++ b/sfont~/sfont~.c
@@ -531,14 +531,14 @@ static void sfont_readhook(t_pd *z, t_symbol *fn, int ac, t_atom *av){
 }
 
 static void sfont_click(t_sfont *x){
-    panel_click_open(x->x_elsefilehandle);
+    elsefile_panel_click_open(x->x_elsefilehandle);
 }
 
 static void sfont_open(t_sfont *x, t_symbol *s){
     if(s && s != &s_)
         fluid_do_load(x, s);
     else
-        panel_click_open(x->x_elsefilehandle);
+        elsefile_panel_click_open(x->x_elsefilehandle);
 }
 
 t_int *sfont_perform(t_int *w){

--- a/shared/elsefile.c
+++ b/shared/elsefile.c
@@ -5,20 +5,19 @@
 #else
 #include <unistd.h>
 #include <dirent.h>
+#include <stdlib.h>
 #endif
 
-//#include <stdlib.h>
-//#include <stdio.h>
-#include <string.h>
 #include "m_pd.h"
 #include "g_canvas.h"
 #include "elsefile.h"
+#include <string.h>
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // OS
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-static int ospath_doabsolute(char *path, char *cwd, char *result){
+static int elsefile_ospath_doabsolute(char *path, char *cwd, char *result){
     if(*path == 0){
         if(result)
             strcpy(result, cwd);
@@ -167,16 +166,16 @@ badpath:
  superfluous slashes and dots), but not longer.  Both args should be unbashed
  (system-independent), cwd should be absolute.  Returns 0 in case of any
  error (LATER revisit). */
-int ospath_length(char *path, char *cwd){ // one extra byte used internally (guarding slash)
-    return(ospath_doabsolute(path, cwd, 0) + 1);
+int elsefile_ospath_length(char *path, char *cwd){ // one extra byte used internally (guarding slash)
+    return(elsefile_ospath_doabsolute(path, cwd, 0) + 1);
 }
 
 /* Copies an absolute path to result.  Arguments: path and cwd, are the same
  as in ospath_length().  Caller should first consult ospath_length(), and
  allocate at least ospath_length() + 1 bytes to the result buffer.
  Should never fail (failure is a bug). */
-char *ospath_absolute(char *path, char *cwd, char *result){
-    ospath_doabsolute(path, cwd, result);
+char *elsefile_ospath_absolute(char *path, char *cwd, char *result){
+    elsefile_ospath_doabsolute(path, cwd, result);
     return(result);
 }
 
@@ -192,7 +191,7 @@ struct _osdir{
 
 /* returns 0 on error, a caller is then expected to call
  loud_syserror(owner, "cannot open \"%s\"", dirname) */
-t_osdir *osdir_open(char *dirname){
+t_osdir *elsefile_osdir_open(char *dirname){
 #ifndef _WIN32
     DIR *handle = opendir(dirname);
     if(handle){
@@ -211,12 +210,12 @@ t_osdir *osdir_open(char *dirname){
 #endif
 }
 
-void osdir_setmode(t_osdir *dp, int flags){
+void elsefile_osdir_setmode(t_osdir *dp, int flags){
     if(dp)
         dp->dir_flags = flags;
 }
 
-void osdir_close(t_osdir *dp){
+void elsefile_osdir_close(t_osdir *dp){
     if(dp){
 #ifndef _WIN32
         closedir(dp->dir_handle);
@@ -225,7 +224,7 @@ void osdir_close(t_osdir *dp){
     }
 }
 
-void osdir_rewind(t_osdir *dp){
+void elsefile_osdir_rewind(t_osdir *dp){
     if(dp){
 #ifndef _WIN32
         rewinddir(dp->dir_handle);
@@ -234,7 +233,7 @@ void osdir_rewind(t_osdir *dp){
     }
 }
 
-char *osdir_next(t_osdir *dp){
+char *elsefile_osdir_next(t_osdir *dp){
 #ifndef _WIN32
     if(dp){
         while((dp->dir_entry = readdir(dp->dir_handle))){
@@ -249,7 +248,7 @@ char *osdir_next(t_osdir *dp){
     return(0);
 }
 
-int osdir_isfile(t_osdir *dp){
+int elsefile_osdir_isfile(t_osdir *dp){
 #ifndef _WIN32
     return(dp && dp->dir_entry && dp->dir_entry->d_type == DT_REG);
 #else
@@ -257,7 +256,7 @@ int osdir_isfile(t_osdir *dp){
 #endif
 }
 
-int osdir_isdir(t_osdir *dp){
+int elsefile_osdir_isdir(t_osdir *dp){
 #ifndef _WIN32
     return(dp && dp->dir_entry && dp->dir_entry->d_type == DT_DIR);
 #else
@@ -333,19 +332,19 @@ static void panel_guidefs(void){
 
 /* This is obsolete, but has to stay, because older versions of miXed libraries
    might overwrite new panel_guidefs().  FIXME we need version control. */
-static void panel_symbol(t_elsefile *f, t_symbol *s){
+static void elsefile_panel_symbol(t_elsefile *f, t_symbol *s){
     if(s && s != &s_ && f->f_panelfn)
         (*f->f_panelfn)(f->f_master, s, 0, 0);
 }
 
-static void panel_path(t_elsefile *f, t_symbol *s1, t_symbol *s2){
+static void elsefile_panel_path(t_elsefile *f, t_symbol *s1, t_symbol *s2){
     if(s2 && s2 != &s_)
         f->f_currentdir = s2;
     if(s1 && s1 != &s_ && f->f_panelfn)
         (*f->f_panelfn)(f->f_master, s1, 0, 0);
 }
 
-static void panel_tick(t_elsefile *f){
+static void elsefile_panel_tick(t_elsefile *f){
     if(f->f_savepanel)
         sys_vgui("panel_open %s {%s}\n", f->f_bindname->s_name, f->f_inidir->s_name);
     else
@@ -354,18 +353,18 @@ static void panel_tick(t_elsefile *f){
 
 /* these are hacks: deferring modal dialog creation in order to allow for
    a message box redraw to happen -- LATER investigate */
-void panel_click_open(t_elsefile *f){
+void elsefile_panel_click_open(t_elsefile *f){
     f->f_inidir = (f->f_currentdir ? f->f_currentdir : &s_);
     clock_delay(f->f_panelclock, 0);
 }
 
-void panel_setopendir(t_elsefile *f, t_symbol *dir){
+void elsefile_panel_setopendir(t_elsefile *f, t_symbol *dir){
     if(f->f_currentdir && f->f_currentdir != &s_){
         if(dir && dir != &s_){
-            int length = ospath_length((char *)(dir->s_name), (char *)(f->f_currentdir->s_name));
+            int length = elsefile_ospath_length((char *)(dir->s_name), (char *)(f->f_currentdir->s_name));
             if(length){
                 char *path = getbytes(length + 1);
-                if(ospath_absolute((char *)(dir->s_name), (char *)(f->f_currentdir->s_name), path))
+                if(elsefile_ospath_absolute((char *)(dir->s_name), (char *)(f->f_currentdir->s_name), path))
                 /* LATER stat (think how to report a failure) */
                     f->f_currentdir = gensym(path);
                 freebytes(path, length + 1);
@@ -378,11 +377,11 @@ void panel_setopendir(t_elsefile *f, t_symbol *dir){
         bug("panel_setopendir");
 }
 
-t_symbol *panel_getopendir(t_elsefile *f){
+t_symbol *elsefile_panel_getopendir(t_elsefile *f){
     return(f->f_currentdir);
 }
 
-void panel_save(t_elsefile *f, t_symbol *inidir, t_symbol *inifile){
+void elsefile_panel_save(t_elsefile *f, t_symbol *inidir, t_symbol *inifile){
     if((f = f->f_savepanel)){
         if(inidir)
             f->f_inidir = inidir;
@@ -394,12 +393,12 @@ void panel_save(t_elsefile *f, t_symbol *inidir, t_symbol *inifile){
     }
 }
 
-void panel_setsavedir(t_elsefile *f, t_symbol *dir){
+void elsefile_panel_setsavedir(t_elsefile *f, t_symbol *dir){
     if((f = f->f_savepanel))
-        panel_setopendir(f, dir);
+        elsefile_panel_setopendir(f, dir);
 }
 
-t_symbol *panel_getsavedir(t_elsefile *f){
+t_symbol *elsefile_panel_getsavedir(t_elsefile *f){
     return(f->f_savepanel ? f->f_savepanel->f_currentdir : 0);
 }
 
@@ -466,7 +465,7 @@ t_elsefile *elsefile_new(t_pd *master, t_elsefilefn readfn, t_elsefilefn writefn
         pd_bind((t_pd *)result, result->f_bindname);
         result->f_currentdir = result->f_inidir = canvas_getdir(result->f_canvas);
         result->f_panelfn = readfn;
-        result->f_panelclock = clock_new(result, (t_method)panel_tick);
+        result->f_panelclock = clock_new(result, (t_method)elsefile_panel_tick);
         f = (t_elsefile *)pd_new(elsefile_class);
         f->f_master = master;
         f->f_canvas = result->f_canvas;
@@ -475,7 +474,7 @@ t_elsefile *elsefile_new(t_pd *master, t_elsefilefn readfn, t_elsefilefn writefn
         pd_bind((t_pd *)f, f->f_bindname);
         f->f_currentdir = f->f_inidir = result->f_currentdir;
         f->f_panelfn = writefn;
-        f->f_panelclock = clock_new(f, (t_method)panel_tick);
+        f->f_panelclock = clock_new(f, (t_method)elsefile_panel_tick);
         result->f_savepanel = f;
     }
     else
@@ -487,8 +486,8 @@ void elsefile_setup(void){
     if(!elsefile_class){
         ps__C = gensym("#C");
         elsefile_class = class_new(gensym("_elsefile"), 0, 0,sizeof(t_elsefile), CLASS_PD | CLASS_NOINLET, 0);
-        class_addsymbol(elsefile_class, panel_symbol);
-        class_addmethod(elsefile_class, (t_method)panel_path,gensym("path"), A_SYMBOL, A_DEFSYM, 0);
+        class_addsymbol(elsefile_class, elsefile_panel_symbol);
+        class_addmethod(elsefile_class, (t_method)elsefile_panel_path,gensym("path"), A_SYMBOL, A_DEFSYM, 0);
         panel_guidefs();
     }
 }

--- a/shared/elsefile.h
+++ b/shared/elsefile.h
@@ -12,16 +12,16 @@ EXTERN_STRUCT _osdir;
 #define OSDIR_elsefileMODE  1
 #define OSDIR_DIRMODE   2
 
-int ospath_length(char *path, char *cwd);
-char *ospath_absolute(char *path, char *cwd, char *result);
+int elsefile_ospath_length(char *path, char *cwd);
+char *elsefile_ospath_absolute(char *path, char *cwd, char *result);
 
-t_osdir *osdir_open(char *dirname);
-void osdir_setmode(t_osdir *dp, int flags);
-void osdir_close(t_osdir *dp);
-void osdir_rewind(t_osdir *dp);
-char *osdir_next(t_osdir *dp);
-int osdir_isfile(t_osdir *dp);
-int osdir_isdir(t_osdir *dp);
+t_osdir *elsefile_osdir_open(char *dirname);
+void elsefile_osdir_setmode(t_osdir *dp, int flags);
+void elsefile_osdir_close(t_osdir *dp);
+void elsefile_osdir_rewind(t_osdir *dp);
+char *elsefile_osdir_next(t_osdir *dp);
+int elsefile_osdir_isfile(t_osdir *dp);
+int elsefile_osdir_isdir(t_osdir *dp);
 
 #endif
 
@@ -33,12 +33,12 @@ EXTERN_STRUCT _elsefile;
 
 typedef void (*t_elsefilefn)(t_pd *, t_symbol *, int, t_atom *);
 
-void panel_click_open(t_elsefile *f);
-void panel_setopendir(t_elsefile *f, t_symbol *dir);
-t_symbol *panel_getopendir(t_elsefile *f);
-void panel_save(t_elsefile *f, t_symbol *inidir, t_symbol *inifile);
-void panel_setsavedir(t_elsefile *f, t_symbol *dir);
-t_symbol *panel_getsavedir(t_elsefile *f);
+void elsefile_panel_click_open(t_elsefile *f);
+void elsefile_panel_setopendir(t_elsefile *f, t_symbol *dir);
+t_symbol *elsefile_panel_getopendir(t_elsefile *f);
+void elsefile_panel_save(t_elsefile *f, t_symbol *inidir, t_symbol *inifile);
+void elsefile_panel_setsavedir(t_elsefile *f, t_symbol *dir);
+t_symbol *elsefile_panel_getsavedir(t_elsefile *f);
 int elsefile_ismapped(t_elsefile *f);
 int elsefile_isloading(t_elsefile *f);
 int elsefile_ispasting(t_elsefile *f);


### PR DESCRIPTION
There we go again. This reverts your rev. ab365eb4432c493facc0232dfc8d88e6a54cff7b and rev. 59adf7d49304e65ba8dc4ec4cdbab44054b15194, and replays the ill-fated #1423 on top.