### PR TITLE
fix a few more typos in keycode

### DIFF
--- a/Classes/Source/keycode.c
+++ b/Classes/Source/keycode.c
@@ -2,7 +2,8 @@
 
 /* common mapping for every platform, from https://github.com/depp/keycode */
 #ifdef __APPLE__
-const unsigned char KEYCODE_TO_HID[128] = {
+
+static const unsigned char KEYCODE_TO_HID[128] = {
     4,22,7,9,11,10,29,27,6,25,0,5,20,26,8,21,28,23,30,31,32,33,35,34,46,38,36,
     45,37,39,48,18,24,47,12,19,158,15,13,52,14,51,49,54,56,17,16,55,43,44,53,42,
     0,41,231,227,225,57,226,224,229,230,228,0,108,220,0,85,0,87,0,216,0,0,127,
@@ -10,13 +11,16 @@ const unsigned char KEYCODE_TO_HID[128] = {
     65,66,0,68,0,104,107,105,0,67,0,69,0,106,117,74,75,76,61,77,59,78,58,80,79,
     81,82,0
 };
-unsigned keycode_to_hid(unsigned scancode) {
+
+static unsigned keycode_to_hid(unsigned scancode) {
     if (scancode >= 128)
         return 0;
     return KEYCODE_TO_HID[scancode];
 }
+
 #elif defined _WIN32
-const unsigned char KEYCODE_TO_HID[256] = {
+
+static const unsigned char KEYCODE_TO_HID[256] = {
     0,41,30,31,32,33,34,35,36,37,38,39,45,46,42,43,20,26,8,21,23,28,24,12,18,19,
     47,48,158,224,4,22,7,9,10,11,13,14,15,51,52,53,225,49,29,27,6,25,5,17,16,54,
     55,56,229,0,226,0,57,58,59,60,61,62,63,64,65,66,67,72,71,0,0,0,0,0,0,0,0,0,
@@ -26,13 +30,16 @@ const unsigned char KEYCODE_TO_HID[256] = {
     0,0,0,0,0,0,0,0,0,74,82,75,0,80,0,79,0,77,81,78,73,76,0,0,0,0,0,0,0,227,231,
     0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
 };
-unsigned keycode_to_hid(unsigned scancode) {
+
+static unsigned keycode_to_hid(unsigned scancode) {
     if (scancode >= 256)
         return 0;
     return KEYCODE_TO_HID[scancode];
 }
+
 #else
-const unsigned char KEYCODE_TO_HID[256] = {
+
+static const unsigned char KEYCODE_TO_HID[256] = {
     0,41,30,31,32,33,34,35,36,37,38,39,45,46,42,43,20,26,8,21,23,28,24,12,18,19,
     47,48,158,224,4,22,7,9,10,11,13,14,15,51,52,53,225,49,29,27,6,25,5,17,16,54,
     55,56,229,85,226,44,57,58,59,60,61,62,63,64,65,66,67,83,71,95,96,97,86,92,
@@ -44,13 +51,14 @@ const unsigned char KEYCODE_TO_HID[256] = {
     0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
 };
 
-unsigned keycode_to_hid(unsigned scancode) {
+static unsigned keycode_to_hid(unsigned scancode) {
     /* xorg differs from kernel values */
     scancode -= 8;
     if (scancode >= 256)
         return 0;
     return KEYCODE_TO_HID[scancode];
 }
+
 #endif
 
 static t_class *keycode_class;

--- a/Classes/Source/keycode.c
+++ b/Classes/Source/keycode.c
@@ -106,7 +106,7 @@ static void *keycode_new(void)
 {
     t_keycode *x = (t_keycode *)pd_new(keycode_class);
     x->x_outlet1 = outlet_new(&x->x_obj, &s_float);
-    x->x_outlet2 = outlet_new(&x->x_obj, &s_symbol);
+    x->x_outlet2 = outlet_new(&x->x_obj, &s_float);
     object_list_bind(&x->x_obj.ob_pd);
     return (x);
 }
@@ -119,6 +119,10 @@ static void keycode_list(t_keycode *x, t_symbol *s, int ac, t_atom *av)
 
 static void object_list_iterate(t_objectlist *x, t_symbol *s, int argc, t_atom *argv) {
     t_listelem *e;
+    if (argc < 2) {
+        pd_error(0, "keycode: not enough args");
+        return;
+    }
     argv[1].a_w.w_float = keycode_to_hid(argv[1].a_w.w_float);
     for (e = x->b_list; e; e = e->e_next)
         pd_list(e->e_who, s, argc, argv);
@@ -151,7 +155,7 @@ void keycode_setup(void)
     sys_vgui("bind all <KeyRelease> {+ pdsend \"#keycode 0 [expr %%k >> 24]\"}\n");
     #else /* __APPLE__ */
     sys_vgui("bind all <KeyPress> {+ pdsend \"#keycode 1 %%k\"}\n");
-    sys_vgui("bind all <KeyPress> {+ pdsend \"#keycode 0 %%k\"}\n");
+    sys_vgui("bind all <KeyRelease> {+ pdsend \"#keycode 0 %%k\"}\n");
     #endif /* NOT __APPLE__ */
 }
 


### PR DESCRIPTION
fix outlet 'symbol' to be a float

fix bad duplicate "KeyPress" in non-__APPLE__

a little bit of bounds checking