### PR TITLE
Try adding correct windows support for keycode

### DIFF
--- a/Classes/Source/keycode.c
+++ b/Classes/Source/keycode.c
@@ -20,6 +20,8 @@ static unsigned keycode_to_hid(unsigned scancode) {
 
 #elif defined _WIN32
 
+#include <Windows.h>
+
 static const unsigned char KEYCODE_TO_HID[256] = {
     0,41,30,31,32,33,34,35,36,37,38,39,45,46,42,43,20,26,8,21,23,28,24,12,18,19,
     47,48,158,224,4,22,7,9,10,11,13,14,15,51,52,53,225,49,29,27,6,25,5,17,16,54,
@@ -31,7 +33,10 @@ static const unsigned char KEYCODE_TO_HID[256] = {
     0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
 };
 
+static unsigned layout;
+
 static unsigned keycode_to_hid(unsigned scancode) {
+    scancode = MapVirtualKeyEx(scancode, MAPVK_VK_TO_VSC, layout);
     if (scancode >= 256)
         return 0;
     return KEYCODE_TO_HID[scancode];
@@ -162,6 +167,9 @@ void keycode_setup(void)
     sys_vgui("bind all <KeyPress> {+ pdsend \"#keycode 1 [expr %%k >> 24]\"}\n");
     sys_vgui("bind all <KeyRelease> {+ pdsend \"#keycode 0 [expr %%k >> 24]\"}\n");
     #else /* __APPLE__ */
+    #ifdef _WIN32
+    layout = GetKeyboardLayout(0);
+    #endif /* _WIN32 */
     sys_vgui("bind all <KeyPress> {+ pdsend \"#keycode 1 %%k\"}\n");
     sys_vgui("bind all <KeyRelease> {+ pdsend \"#keycode 0 %%k\"}\n");
     #endif /* NOT __APPLE__ */


### PR DESCRIPTION
Try getting windows ```[keycode]``` working by looking up the scancode from the virtual key. ```GetKeyboardLayout``` is called once in the setup function and stored in a static variable in order to avoid multiple calls.