### PR TITLE
Fixes for Purr data compatibility

### DIFF
--- a/Classes/Source/button.c
+++ b/Classes/Source/button.c
@@ -3,6 +3,8 @@
 #include "m_pd.h"
 #include "g_canvas.h"
 
+#include "compat.h"
+
 static t_class *button_class, *edit_proxy_class;
 static t_widgetbehavior button_widgetbehavior;
 

--- a/Classes/Source/compat.h
+++ b/Classes/Source/compat.h
@@ -1,0 +1,14 @@
+
+#ifndef COMPAT_H
+#define COMPAT_H
+
+// Definitions for Purr Data compatibility which still has an older API than
+// current vanilla.
+
+#ifndef IHEIGHT
+// Purr Data doesn't have these, hopefully the vanilla values will work
+#define IHEIGHT 3       /* height of an inlet in pixels */
+#define OHEIGHT 3       /* height of an outlet in pixels */
+#endif
+
+#endif

--- a/Classes/Source/del~.c
+++ b/Classes/Source/del~.c
@@ -318,18 +318,19 @@ static void *del_out_new(t_symbol *s, int ac, t_atom *av){
 
 // ----------------------- global setup ----------------
 static void *del_new(t_symbol *s, int ac, t_atom *av){
+    t_pd *newest = pd_newest();
     if(!ac)
-        pd_this->pd_newest = del_in_new(s, ac, av);
+        newest = del_in_new(s, ac, av);
     else{
         t_symbol *s2 = av[0].a_w.w_symbol;
         if(s2 == gensym("in"))
-            pd_this->pd_newest = del_in_new(s, ac-1, av+1);
+            newest = del_in_new(s, ac-1, av+1);
         else if(s2 == gensym("out"))
-            pd_this->pd_newest = del_out_new(s, ac-1, av+1);
+            newest = del_out_new(s, ac-1, av+1);
         else
-            pd_this->pd_newest = del_in_new(s, ac, av);
+            newest = del_in_new(s, ac, av);
     }
-    return(pd_this->pd_newest);
+    return(newest);
 }
 
 void del_tilde_setup(void){

--- a/Classes/Source/function.c
+++ b/Classes/Source/function.c
@@ -6,6 +6,8 @@
 #include <g_canvas.h>
 #include "buffer.h"
 
+#include "compat.h"
+
 static t_class *function_class, *edit_proxy_class;
 static t_widgetbehavior function_widgetbehavior;
 

--- a/Classes/Source/keyboard.c
+++ b/Classes/Source/keyboard.c
@@ -3,6 +3,8 @@
 #include "m_pd.h"
 #include "g_canvas.h"
 
+#include "compat.h"
+
 #define BLACK_ON    "#FF0000"
 #define BLACK_OFF   "#000000"
 #define WHITE_ON    "#C40000"

--- a/Classes/Source/messbox.c
+++ b/Classes/Source/messbox.c
@@ -4,6 +4,8 @@
 #include <g_canvas.h>
 #include <string.h>
 
+#include "compat.h"
+
 #ifdef _MSC_VER
 #pragma warning( disable : 4244 )
 #pragma warning( disable : 4305 )

--- a/Classes/Source/note.c
+++ b/Classes/Source/note.c
@@ -6,6 +6,8 @@
 #include "m_pd.h"
 #include "g_canvas.h"
 
+#include "compat.h"
+
 #ifndef _WIN32
 #include "s_utf8.h"
 #endif

--- a/Classes/Source/numbox~.c
+++ b/Classes/Source/numbox~.c
@@ -6,6 +6,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "compat.h"
+
 #define MINDIGITS      1
 #define MAX_NUMBOX_LEN 32
 #define MINSIZE        8

--- a/Classes/Source/oscope~.c
+++ b/Classes/Source/oscope~.c
@@ -6,6 +6,8 @@
 #include "g_canvas.h"
 #include "magic.h"
 
+#include "compat.h"
+
 #define SCOPE_MINSIZE       18
 #define SCOPE_MINPERIOD     2
 #define SCOPE_MAXPERIOD     8192

--- a/Classes/Source/pad.c
+++ b/Classes/Source/pad.c
@@ -3,6 +3,8 @@
 #include "m_pd.h"
 #include "g_canvas.h"
 
+#include "compat.h"
+
 static t_class *pad_class, *edit_proxy_class;
 static t_widgetbehavior pad_widgetbehavior;
 

--- a/Classes/Source/pic.c
+++ b/Classes/Source/pic.c
@@ -3,6 +3,8 @@
 #include <m_pd.h>
 #include <g_canvas.h>
 
+#include "compat.h"
+
 #ifdef _MSC_VER
 #include <io.h>
 #else


### PR DESCRIPTION
Here are some proposed changes for making ELSE work with Purr Data. (Currently this needs my testing branch for Purr on GH, see https://github.com/agraef/purr-data/tree/testing. CI builds are available at https://github.com/agraef/purr-data/actions/runs/4097932308, if you want to give it a try yourself.)

The changes are pretty minimal (most of the relevant changes are on the Purr side). There's a new compat.h header file which adds some definitions from vanilla's g_canvas.h which aren't in the Purr API.

Note that I haven't ported any of the gui stuff yet, and there seems to be lots of it. But otherwise it seems to work, here's the osc.parse help patch running in Purr:

![image](https://user-images.githubusercontent.com/2853977/216849977-798b5b67-13e7-4430-9798-a098d813e7b5.png)

Once you merged this PR, I can make ELSE a submodule in Purr and figure out how to build it in this context, so that it can be included in a future release.