### PR TITLE
More fixes for Purr data compatibility

### DIFF
--- a/Classes/Source/compat.h
+++ b/Classes/Source/compat.h
@@ -5,10 +5,21 @@
 // Definitions for Purr Data compatibility which still has an older API than
 // current vanilla.
 
+#include "m_pd.h"
+#include "g_canvas.h"
+
 #ifndef IHEIGHT
 // Purr Data doesn't have these, hopefully the vanilla values will work
 #define IHEIGHT 3       /* height of an inlet in pixels */
 #define OHEIGHT 3       /* height of an outlet in pixels */
+#endif
+
+#ifdef PDL2ORK
+/* This call is needed for the gui parts, which haven't been ported to JS yet
+   anyway, so we just make this a no-op for now. XXXFIXME: Once the gui
+   features have been ported, we need to figure out what exactly is needed
+   here, and implement it in terms of Purr Data's undo/redo system. */
+#define pd_undo_set_objectstate(canvas, x, s, undo_argc, undo_argv, redo_argc, redo_argv) /* no-op  */
 #endif
 
 #endif


### PR DESCRIPTION
As promised (and a lot quicker than expected, too).

Provided a dummy implementation of pd_undo_set_objectstate for now (this is needed for the guis which haven't been ported to nw.js yet anyway). The missing declaration for obj_findsignalscalar in m_imp.h was a glitch on the Purr Data side, fixed in the testing branch now.

This now also compiles cleanly on the Mac, and doesn't crash with the gui objects like keyboard on Linux any more, which is progress. :)

It still throws a gazillions of `legacy tcl command` warnings for the gui objects, but that's expected at this point. Non-gui objects should be working now (I only tested a handful of the help patches, but these all seemed to work fine).