### PR TITLE
Signon fixes

### DIFF
--- a/Classes/Source/else.c
+++ b/Classes/Source/else.c
@@ -53,10 +53,12 @@ void print_else_obj(t_else_obj *x){
         post("(you have %d.%d-%d, you're good!)", major, minor, bugfix);
     }
     else{
+#ifndef PDL2ORK
         pd_error(x, "- ELSE %d.%d-%d %s-%d needs at least Pd %d.%d-%d",
             else_major, else_minor, else_bugfix, STATUS, status_number,
             min_major, min_minor, min_bugfix);
         pd_error(x, "(you have %d.%d-%d, please upgrade)", major, minor, bugfix);
+#endif
     }
     post("-------------------------------------------------------------------");
     post("- NOTE: This library also includes a tutorial that depends");

--- a/Classes/Source/else.c
+++ b/Classes/Source/else.c
@@ -61,10 +61,10 @@ void print_else_obj(t_else_obj *x){
 #endif
     }
     post("-------------------------------------------------------------------");
-    post("- NOTE: This library also includes a tutorial that depends");
-    post("on this library by Alexandre Torres Porres!!!");
-    post("Find the \"Live-Electronics-Tutorial\" folder inside the \"else\"");
-    post("folder. Please check its README on how to install it!");
+    post("- NOTE: There's an accompanying tutorial by Alexandre Torres");
+    post("Porres which we recommend. You can find the tutorial under");
+    post("\"Live-Electronics-Tutorial\" at: https://github.com/porres/pd-else");
+    post("Please check its README on how to install it!");
     post("-------------------------------------------------------------------");
     post("- ALSO NOTE: Loading this binary did not install the ELSE library");
     post("you still need to add it to the \"preferences=>path\"");


### PR DESCRIPTION
As discussed in #1484. First commit disables the errors in the sign-on when building against Purr, second commit rewords the note about the Live-Electronics-Tutorial. If you don't like the latter, just cherry-pick the former.