### PR TITLE
Work around pdlibbuilder overflowing the command line in datafiles_install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -360,7 +360,7 @@ ifeq ($(luamake),yes)
 pdlua_data = ./pdlua/pd.lua
 endif
 
-datafiles = \
+extrafiles = \
 $(wildcard Classes/Abstractions/*.pd) \
 $(wildcard Classes/Abs_components/*.pd) \
 $(wildcard Help-files/*.pd) \
@@ -377,6 +377,7 @@ include $(PDLIBBUILDER_DIR)/Makefile.pdlibbuilder
 install: installplus
 
 installplus:
+	for v in $(extrafiles); do $(INSTALL_DATA) "$$v" "$(installpath)"; done
 ifeq ($(luamake),yes)
 	cp -r ./pdlua/pdlua "${installpath}"/pdlua
 else


### PR DESCRIPTION
As discussed previously. The problem is with datafiles_install in Makefile.pdlibbuilder, which uses GNU make's $(foreach). This expands the command line in-place, overflowing the shell command line if the datafiles list is very large (as it is in ELSE).

Instead, we use the existing installplus target to install the auxiliary datafiles (renamed to extrafiles) using a proper shell command which is much more efficient. So you can now add as many help patches as you want, and it won't break `make install` any time soon. ;-)