### PR TITLE
adrresses -> addresses

### DIFF
--- a/Help-files/osc.route-help.pd
+++ b/Help-files/osc.route-help.pd
@@ -98,7 +98,7 @@
 #X text 151 369 anything;
 #X text 209 370 - unmatched message;
 #X text 123 412 1) anything -;
-#X text 209 412 list of OSC adrresses to route to;
+#X text 209 412 list of OSC addresses to route to;
 #X msg 199 163 /hz/a 440;
 #X msg 212 185 /hz/b 880;
 #X obj 199 235 else/osc.route /hz;

--- a/Help-files/route2-help.pd
+++ b/Help-files/route2-help.pd
@@ -59,7 +59,7 @@
 #X text 196 477 input message if no match was found, f 51;
 #X obj 247 285 else/route2 x 2, f 21;
 #X obj 36 373 route;
-#X text 219 510 list of adrresses to route to (floats or symbols);
+#X text 219 510 list of addresses to route to (floats or symbols);
 #X text 64 84 [route2] is similar to route \, but it doesn't trim the
 list selector and always outputs messages with a proper selector. Another
 difference is that you can mix floats and symbols as arguments. Each


### PR DESCRIPTION
fixes two documents that have `adrresses` instead of `addresses`
@porres 