### PR TITLE
backlash / backlashes -> backslash / backslashes

### DIFF
--- a/Help-files/args-help.pd
+++ b/Help-files/args-help.pd
@@ -96,7 +96,7 @@ is a very simple example on how it works.;
 #X obj 457 342 else/args-example foo 100 \$0-x \\\$0 \$1 \$2-x;
 #X msg 457 318 bang;
 #X text 60 326 Note how dollar signs (such as "\$0" \, "\$1" or "\$2-x")
-get expanded unless you escape them with a backlash ("\$2-x" may appear
+get expanded unless you escape them with a backslash ("\$2-x" may appear
 as an unexpanded symbol \, but it actually gets expanded if this abstraction
 is called inside another that contains arguments).;
 #X text 415 38 When you send any message (float \, list \, symbol)

--- a/Help-files/circle-help.pd
+++ b/Help-files/circle-help.pd
@@ -386,7 +386,7 @@ messages or '-send'/'-receive' flags., f 31;
 #X msg 65 222 0 0;
 #X obj 354 234 else/circle 127 -1 1 -1 1 1 255 255 255 255 255 255
 0 0 0 1 0 0 63.5 63.5 empty empty 0;
-#X text 76 110 Make sure to escape "\$0" properly with backlashes (as
+#X text 76 110 Make sure to escape "\$0" properly with backslashes (as
 in: "\\\$0")., f 24;
 #X obj 169 301 else/display;
 #X obj 65 309 else/display;

--- a/Help-files/function-help.pd
+++ b/Help-files/function-help.pd
@@ -181,7 +181,7 @@
 #X obj 99 126 else/initmess send \\\$0-function-out \, receive \\\$0-function-in;
 #X obj 343 191 s \$0-function-in;
 #X obj 345 235 r \$0-function-out;
-#X text 94 40 You can also set send/receive names with the 'send'/'receive' messages or '-send'/'-receive' flags. Make sure to escape "\$0" properly with backlashes (as in: "\\\$0") when using messages. Setting these to 'empty' removes the send/receive symbols., f 67;
+#X text 94 40 You can also set send/receive names with the 'send'/'receive' messages or '-send'/'-receive' flags. Make sure to escape "\$0" properly with backslashes (as in: "\\\$0") when using messages. Setting these to 'empty' removes the send/receive symbols., f 67;
 #X text 103 372 Note that when you set a receive or send symbol \, the corresponding inlet/outlet does not get drawn when you're in edit mode. This is an indicative that the object has a send or receive symbol., f 66;
 #X connect 1 0 4 0;
 #X connect 2 0 7 0;

--- a/Help-files/multi.vsl-help.pd
+++ b/Help-files/multi.vsl-help.pd
@@ -298,7 +298,7 @@ messages or '-send'/'-receive' flags., f 31;
 #X msg 392 171 receive empty \, send empty, f 16;
 #X text 82 144 Setting these to 'empty' removes the send/receive symbols.
 , f 32;
-#X text 81 102 Make sure to escape "\$0" properly with backlashes (as
+#X text 81 102 Make sure to escape "\$0" properly with backslashes (as
 in: "\\\$0")., f 24;
 #X obj 175 292 else/display;
 #X obj 71 299 else/display;

--- a/Help-files/slider2d-help.pd
+++ b/Help-files/slider2d-help.pd
@@ -361,7 +361,7 @@ messages or '-send'/'-receive' flags., f 31;
 #X msg 386 181 receive empty \, send empty, f 16;
 #X text 76 154 Setting these to 'empty' removes the send/receive symbols.
 , f 32;
-#X text 75 112 Make sure to escape "\$0" properly with backlashes (as
+#X text 75 112 Make sure to escape "\$0" properly with backslashes (as
 in: "\\\$0")., f 24;
 #X obj 169 302 else/display;
 #X obj 65 309 else/display;

--- a/Live-Electronics-Tutorial/Part.01-The.Basics/01-Pd.Quickstart/2.Syntax/6.Escape/2.More.Examples.pd
+++ b/Live-Electronics-Tutorial/Part.01-The.Basics/01-Pd.Quickstart/2.Syntax/6.Escape/2.More.Examples.pd
@@ -47,10 +47,10 @@ box. You actually need the expanded symbol that comes out of the object
 match an object with a literal "\\\$0-x" \, and it must be clear now
 how it is not the same thing \, as [receive \\\$0-x] is not actually
 loading the locality variable., f 65;
-#X text 52 24 The backlash character is used in Pd to escape special
+#X text 52 24 The backslash character is used in Pd to escape special
 characters that are handled differently in Pd. Such characters are:
 commas \, semicolons \, space dollar signs (as in the locality syntax)
-and the backlash character itself. See below how to create symbols
+and the backslash character itself. See below how to create symbols
 with commas and spaces., f 66;
 #X text 52 239 Here's another example. Below we have a list where commas
 and semicolons are escaped and therefore they are not treated as they


### PR DESCRIPTION
this corrects a bunch of places where backlash is used instead of backslash
@porres 