### PR TITLE
lenghts -> lengths

### DIFF
--- a/shared/aubio/src/spectral/filterbank.c
+++ b/shared/aubio/src/spectral/filterbank.c
@@ -27,7 +27,7 @@
 #include "spectral/filterbank.h"
 #include "mathutils.h"
 
-/** \brief A structure to store a set of n_filters filters of lenghts win_s */
+/** \brief A structure to store a set of n_filters filters of lengths win_s */
 struct _aubio_filterbank_t
 {
   uint_t win_s;


### PR DESCRIPTION
one comment in code that typos `lenghts` instead of `lengths`
@porres 