### PR TITLE
Adding libpcre to fix dependency miss on Linux

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -28,7 +28,7 @@ jobs:
         
 
     - name: Install FluidSynth deps
-      run: sudo apt install cmake libglib2.0-dev libsndfile1-dev patchelf -y
+      run: sudo apt install cmake libglib2.0-dev libpcre++-dev libsndfile1-dev patchelf -y
 
     - name: Download and build FluidSynth
       run: | 


### PR DESCRIPTION
Oi, isso adiciona o libpcre que ta faltando pro pessoal do linux...

Só que você precisa fazer o upload dessa compilação que fica em Actions-> `[último commit`] -> em Artefatos.

![asd](https://user-images.githubusercontent.com/31707161/232896920-10f2b965-7436-40fd-8298-e97e07030ee1.png)

Na minha máquina virtual funcionou, pedir pro pessoal testar.