### PR TITLE
Add Github Actions for Windows 64bits

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -13,82 +13,83 @@ jobs:
 # ===============================================================
 # ===============================================================
 # ===============================================================
-  # Linux-Build:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: actions/checkout@v3
-  #   - name: Install PureData
-  #     run: sudo apt-get install puredata -y 
+  Linux-Build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install PureData
+      run: sudo apt-get install puredata -y 
 
-  #   - name: Downloads pd-Sources 
-  #     run: | 
-  #       PD_URL=$(curl -L -s https://api.github.com/repos/pure-data/pure-data/tags | grep zipball_url | grep -v latest | grep -v pd-0.52 | grep -v tagtest | head -n 1 | cut -d '"' -f 4)
-  #       curl -L -o pure-data.zip $PD_URL
-  #       unzip pure-data.zip
-  #       rm pure-data.zip
-  #       mv pure-data-* pure-data
+    - name: Downloads pd-Sources 
+      run: | 
+        PD_URL=$(curl -L -s https://api.github.com/repos/pure-data/pure-data/tags | grep zipball_url | grep -v latest | grep -v pd-0.52 | grep -v tagtest | head -n 1 | cut -d '"' -f 4)
+        curl -L -o pure-data.zip $PD_URL
+        unzip pure-data.zip
+        rm pure-data.zip
+        mv pure-data-* pure-data
 
-  #   - name: Install FluidSynth deps
-  #     run: sudo apt install cmake libglib2.0-dev libpcre++-dev libsndfile1-dev patchelf -y
+    - name: Install FluidSynth deps
+      run: sudo apt install cmake libglib2.0-dev libpcre++-dev libsndfile1-dev patchelf -y
 
-  #   - name: Download and build FluidSynth
-  #     run: | 
-  #       mkdir ./else-Linux 
-  #       cd sfont~
-  #       URL=$(curl -L -s https://api.github.com/repos/FluidSynth/fluidsynth/releases/latest | grep zipball_url | cut -d '"' -f 4)
-  #       curl -L -o fluidsynth.zip $URL
-  #       unzip fluidsynth.zip
-  #       rm fluidsynth.zip
-  #       mv FluidSynth-* FluidSynth
-  #       cd FluidSynth
-  #       mkdir build
-  #       cd build
-  #       cmake -Denable-libsndfile=on -Denable-jack=off -Denable-alsa=off -Denable-oss=off -Denable-pulseaudio=off -Denable-ladspa=off -Denable-aufile=off -Denable-network=off -Denable-ipv6=off -Denable-getopt=off -Denable-sdl2=off -Denable-threads=off ..
-  #       sudo ldconfig /lib/x86_64-linux-gnu/
-  #       sudo ldconfig -v
-  #       sudo make install
-  #       cd ../..
-  #       make PDINCLUDEDIR=${{github.workspace}}/pure-data/src
+    - name: build FluidSynth
+      run: | 
+        mkdir ./else-Linux 
+        cd sfont~
+        URL=$(curl -L -s https://api.github.com/repos/FluidSynth/fluidsynth/releases/latest | grep zipball_url | cut -d '"' -f 4)
+        curl -L -o fluidsynth.zip $URL
+        unzip fluidsynth.zip
+        rm fluidsynth.zip
+        mv FluidSynth-* FluidSynth
+        cd FluidSynth
+        mkdir build
+        cd build
+        cmake -Denable-libsndfile=on -Denable-jack=off -Denable-alsa=off -Denable-oss=off -Denable-pulseaudio=off -Denable-ladspa=off -Denable-aufile=off -Denable-network=off -Denable-ipv6=off -Denable-getopt=off -Denable-sdl2=off -Denable-threads=off ..
+        sudo ldconfig /lib/x86_64-linux-gnu/
+        sudo ldconfig -v
+        sudo make install 
+    
+    - name: Add Dynamic libraries 
+      run: |
+        sudo sh -c 'echo "/lib/x86_64-linux-gnu/" >> /etc/ld.so.conf'
+        sudo sh -c 'echo "/lib64/" >> /etc/ld.so.conf'
+        sudo sh -c 'echo "/usr/local/lib/" >> /etc/ld.so.conf'
+        sudo ldconfig 
+        sudo ldconfig -v
+
+    - name: Build sfont~
+      run: |
+        cd sfont~
+        make PDLIBDIR=${{github.workspace}}/else-Linux/ localdep_linux
+
+    - name: Build plaits~
+      run: |
+        cd plaits~
+        make PDINCLUDEDIR=${{github.workspace}}/pure-data/src 
+
+    - name: Build pd-else
+      run: | 
+        make PDINCLUDEDIR=./pure-data/src/
+
+    - name: Create Library Folder
+      run: | 
+        cp *.pd_linux ./else-Linux
+        cp Help-files/* ./else-Linux
+        cp Classes/libpd-abs/* ./else-Linux
+        cp Classes/Abstractions/* ./else-Linux
+        cp Classes/Abs_components/* ./else-Linux
+        cp -r Live-Electronics-Tutorial ./else-Linux
+        cp plaits~/*.pd_linux ./else-Linux
+        ./sfont~/scripts/localdeps.linux.sh ./else-Linux/sfont~.pd_linux
+        cp extra/* ./else-Linux
+        cp README.pdf ./else-Linux
+        mv -v ./else-Linux/sfont~/* ./else-Linux/
+        rm -rf ./else-Linux/sfont~
         
-  #   - name: Add Dynamic libraries 
-  #     run: |
-  #       sudo sh -c 'echo "/lib/x86_64-linux-gnu/" >> /etc/ld.so.conf'
-  #       sudo sh -c 'echo "/lib64/" >> /etc/ld.so.conf'
-  #       sudo sh -c 'echo "/usr/local/lib/" >> /etc/ld.so.conf'
-  #       sudo ldconfig 
-  #       sudo ldconfig -v
-
-  #   - name: Build sfont~
-  #     run: |
-  #       cd sfont~
-  #       make PDLIBDIR=${{github.workspace}}/else-Linux/ localdep_linux
-
-  #   - name: Build plaits~
-  #     run: |
-
-
-        
-  #   - name: Compile Objects
-  #     run: make PDINCLUDEDIR=./pure-data/src/
-
-  #   - name: Create Library Folder
-  #     run: | 
-  #       cp *.pd_linux ./else-Linux
-  #       cp Help-files/* ./else-Linux
-  #       cp Classes/libpd-abs/* ./else-Linux
-  #       cp Classes/Abstractions/* ./else-Linux
-  #       cp Classes/Abs_components/* ./else-Linux
-  #       cp -r Live-Electronics-Tutorial ./else-Linux
-  #       cp extra/* ./else-Linux
-  #       cp README.pdf ./else-Linux
-  #       mv -v ./else-Linux/sfont~/* ./else-Linux/
-  #       rm -rf ./else-Linux/sfont~
-        
-  #   - name: Upload Zip
-  #     uses: actions/upload-artifact@v3
-  #     with:
-  #       name: else-MAIN-LINUX64-Bits
-  #       path: ./else-Linux/*
+    - name: Upload Zip
+      uses: actions/upload-artifact@v3
+      with:
+        name: else-MAIN-LINUX64-Bits
+        path: ./else-Linux/*
 
 # ===============================================================
 # ===============================================================

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -13,82 +13,82 @@ jobs:
 # ===============================================================
 # ===============================================================
 # ===============================================================
-  Linux-Build:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: Install PureData
-      run: sudo apt-get install puredata -y 
+  # Linux-Build:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - uses: actions/checkout@v3
+  #   - name: Install PureData
+  #     run: sudo apt-get install puredata -y 
 
-    - name: Downloads pd-Sources 
-      run: | 
-        PD_URL=$(curl -L -s https://api.github.com/repos/pure-data/pure-data/tags | grep zipball_url | grep -v latest | grep -v pd-0.52 | grep -v tagtest | head -n 1 | cut -d '"' -f 4)
-        curl -L -o pure-data.zip $PD_URL
-        unzip pure-data.zip
-        rm pure-data.zip
-        mv pure-data-* pure-data
+  #   - name: Downloads pd-Sources 
+  #     run: | 
+  #       PD_URL=$(curl -L -s https://api.github.com/repos/pure-data/pure-data/tags | grep zipball_url | grep -v latest | grep -v pd-0.52 | grep -v tagtest | head -n 1 | cut -d '"' -f 4)
+  #       curl -L -o pure-data.zip $PD_URL
+  #       unzip pure-data.zip
+  #       rm pure-data.zip
+  #       mv pure-data-* pure-data
 
-    - name: Install FluidSynth deps
-      run: sudo apt install cmake libglib2.0-dev libpcre++-dev libsndfile1-dev patchelf -y
+  #   - name: Install FluidSynth deps
+  #     run: sudo apt install cmake libglib2.0-dev libpcre++-dev libsndfile1-dev patchelf -y
 
-    - name: Download and build FluidSynth
-      run: | 
-        mkdir ./else-Linux 
-        cd sfont~
-        URL=$(curl -L -s https://api.github.com/repos/FluidSynth/fluidsynth/releases/latest | grep zipball_url | cut -d '"' -f 4)
-        curl -L -o fluidsynth.zip $URL
-        unzip fluidsynth.zip
-        rm fluidsynth.zip
-        mv FluidSynth-* FluidSynth
-        cd FluidSynth
-        mkdir build
-        cd build
-        cmake -Denable-libsndfile=on -Denable-jack=off -Denable-alsa=off -Denable-oss=off -Denable-pulseaudio=off -Denable-ladspa=off -Denable-aufile=off -Denable-network=off -Denable-ipv6=off -Denable-getopt=off -Denable-sdl2=off -Denable-threads=off ..
-        sudo ldconfig /lib/x86_64-linux-gnu/
-        sudo ldconfig -v
-        sudo make install
-        cd ../..
-        make PDINCLUDEDIR=${{github.workspace}}/pure-data/src
+  #   - name: Download and build FluidSynth
+  #     run: | 
+  #       mkdir ./else-Linux 
+  #       cd sfont~
+  #       URL=$(curl -L -s https://api.github.com/repos/FluidSynth/fluidsynth/releases/latest | grep zipball_url | cut -d '"' -f 4)
+  #       curl -L -o fluidsynth.zip $URL
+  #       unzip fluidsynth.zip
+  #       rm fluidsynth.zip
+  #       mv FluidSynth-* FluidSynth
+  #       cd FluidSynth
+  #       mkdir build
+  #       cd build
+  #       cmake -Denable-libsndfile=on -Denable-jack=off -Denable-alsa=off -Denable-oss=off -Denable-pulseaudio=off -Denable-ladspa=off -Denable-aufile=off -Denable-network=off -Denable-ipv6=off -Denable-getopt=off -Denable-sdl2=off -Denable-threads=off ..
+  #       sudo ldconfig /lib/x86_64-linux-gnu/
+  #       sudo ldconfig -v
+  #       sudo make install
+  #       cd ../..
+  #       make PDINCLUDEDIR=${{github.workspace}}/pure-data/src
         
-    - name: Add Dynamic libraries 
-      run: |
-        sudo sh -c 'echo "/lib/x86_64-linux-gnu/" >> /etc/ld.so.conf'
-        sudo sh -c 'echo "/lib64/" >> /etc/ld.so.conf'
-        sudo sh -c 'echo "/usr/local/lib/" >> /etc/ld.so.conf'
-        sudo ldconfig 
-        sudo ldconfig -v
+  #   - name: Add Dynamic libraries 
+  #     run: |
+  #       sudo sh -c 'echo "/lib/x86_64-linux-gnu/" >> /etc/ld.so.conf'
+  #       sudo sh -c 'echo "/lib64/" >> /etc/ld.so.conf'
+  #       sudo sh -c 'echo "/usr/local/lib/" >> /etc/ld.so.conf'
+  #       sudo ldconfig 
+  #       sudo ldconfig -v
 
-    - name: Build sfont~
-      run: |
-        cd sfont~
-        make PDLIBDIR=${{github.workspace}}/else-Linux/ localdep_linux
+  #   - name: Build sfont~
+  #     run: |
+  #       cd sfont~
+  #       make PDLIBDIR=${{github.workspace}}/else-Linux/ localdep_linux
 
-    - name: Build plaits~
-      run: |
+  #   - name: Build plaits~
+  #     run: |
 
 
         
-    - name: Compile Objects
-      run: make PDINCLUDEDIR=./pure-data/src/
+  #   - name: Compile Objects
+  #     run: make PDINCLUDEDIR=./pure-data/src/
 
-    - name: Create Library Folder
-      run: | 
-        cp *.pd_linux ./else-Linux
-        cp Help-files/* ./else-Linux
-        cp Classes/libpd-abs/* ./else-Linux
-        cp Classes/Abstractions/* ./else-Linux
-        cp Classes/Abs_components/* ./else-Linux
-        cp -r Live-Electronics-Tutorial ./else-Linux
-        cp extra/* ./else-Linux
-        cp README.pdf ./else-Linux
-        mv -v ./else-Linux/sfont~/* ./else-Linux/
-        rm -rf ./else-Linux/sfont~
+  #   - name: Create Library Folder
+  #     run: | 
+  #       cp *.pd_linux ./else-Linux
+  #       cp Help-files/* ./else-Linux
+  #       cp Classes/libpd-abs/* ./else-Linux
+  #       cp Classes/Abstractions/* ./else-Linux
+  #       cp Classes/Abs_components/* ./else-Linux
+  #       cp -r Live-Electronics-Tutorial ./else-Linux
+  #       cp extra/* ./else-Linux
+  #       cp README.pdf ./else-Linux
+  #       mv -v ./else-Linux/sfont~/* ./else-Linux/
+  #       rm -rf ./else-Linux/sfont~
         
-    - name: Upload Zip
-      uses: actions/upload-artifact@v3
-      with:
-        name: else-MAIN-LINUX64-Bits
-        path: ./else-Linux/*
+  #   - name: Upload Zip
+  #     uses: actions/upload-artifact@v3
+  #     with:
+  #       name: else-MAIN-LINUX64-Bits
+  #       path: ./else-Linux/*
 
 # ===============================================================
 # ===============================================================

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -124,4 +124,4 @@ jobs:
         cd sfont~
         make 
         cd .. 
-        make PDINCLUDEDIR=${{github.workspace}}/pure-data/src
+        make 

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -123,5 +123,5 @@ jobs:
         mkdir ./else-Windows 
         cd sfont~
         make 
-        cd ../..
+        cd .. 
         make PDINCLUDEDIR=${{github.workspace}}/pure-data/src

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -9,77 +9,82 @@ on:
     paths-ignore: ['md-help/**', 'Help-files/**']
 
 jobs:
-  # Linux-Build:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: actions/checkout@v3
-  #   - name: Install PureData
-  #     run: sudo apt-get install puredata -y 
+  Linux-Build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install PureData
+      run: sudo apt-get install puredata -y 
 
-  #   - name: Downloads pd-Sources 
-  #     run: | 
-  #       PD_URL=$(curl -L -s https://api.github.com/repos/pure-data/pure-data/tags | grep zipball_url | grep -v latest | grep -v pd-0.52 | grep -v tagtest | head -n 1 | cut -d '"' -f 4)
-  #       curl -L -o pure-data.zip $PD_URL
-  #       unzip pure-data.zip
-  #       rm pure-data.zip
-  #       mv pure-data-* pure-data
+    - name: Downloads pd-Sources 
+      run: | 
+        PD_URL=$(curl -L -s https://api.github.com/repos/pure-data/pure-data/tags | grep zipball_url | grep -v latest | grep -v pd-0.52 | grep -v tagtest | head -n 1 | cut -d '"' -f 4)
+        curl -L -o pure-data.zip $PD_URL
+        unzip pure-data.zip
+        rm pure-data.zip
+        mv pure-data-* pure-data
         
-  #   - name: Install FluidSynth deps
-  #     run: sudo apt install cmake libglib2.0-dev libpcre++-dev libsndfile1-dev patchelf -y
+    - name: Install FluidSynth deps
+      run: sudo apt install cmake libglib2.0-dev libpcre++-dev libsndfile1-dev patchelf -y
 
-  #   - name: Download and build FluidSynth
-  #     run: | 
-  #       mkdir ./else-Linux 
-  #       cd sfont~
-  #       URL=$(curl -L -s https://api.github.com/repos/FluidSynth/fluidsynth/releases/latest | grep zipball_url | cut -d '"' -f 4)
-  #       curl -L -o fluidsynth.zip $URL
-  #       unzip fluidsynth.zip
-  #       rm fluidsynth.zip
-  #       mv FluidSynth-* FluidSynth
-  #       cd FluidSynth
-  #       mkdir build
-  #       cd build
-  #       cmake -Denable-libsndfile=on -Denable-jack=off -Denable-alsa=off -Denable-oss=off -Denable-pulseaudio=off -Denable-ladspa=off -Denable-aufile=off -Denable-network=off -Denable-ipv6=off -Denable-getopt=off -Denable-sdl2=off -Denable-threads=off ..
-  #       sudo ldconfig /lib/x86_64-linux-gnu/
-  #       sudo ldconfig -v
-  #       sudo make install
-  #       cd ../..
-  #       make PDINCLUDEDIR=${{github.workspace}}/pure-data/src
+    - name: Download and build FluidSynth
+      run: | 
+        mkdir ./else-Linux 
+        cd sfont~
+        URL=$(curl -L -s https://api.github.com/repos/FluidSynth/fluidsynth/releases/latest | grep zipball_url | cut -d '"' -f 4)
+        curl -L -o fluidsynth.zip $URL
+        unzip fluidsynth.zip
+        rm fluidsynth.zip
+        mv FluidSynth-* FluidSynth
+        cd FluidSynth
+        mkdir build
+        cd build
+        cmake -Denable-libsndfile=on -Denable-jack=off -Denable-alsa=off -Denable-oss=off -Denable-pulseaudio=off -Denable-ladspa=off -Denable-aufile=off -Denable-network=off -Denable-ipv6=off -Denable-getopt=off -Denable-sdl2=off -Denable-threads=off ..
+        sudo ldconfig /lib/x86_64-linux-gnu/
+        sudo ldconfig -v
+        sudo make install
+        cd ../..
+        make PDINCLUDEDIR=${{github.workspace}}/pure-data/src
         
-  #   - name: Add Dynamic libraries 
-  #     run: |
-  #       sudo sh -c 'echo "/lib/x86_64-linux-gnu/" >> /etc/ld.so.conf'
-  #       sudo sh -c 'echo "/lib64/" >> /etc/ld.so.conf'
-  #       sudo sh -c 'echo "/usr/local/lib/" >> /etc/ld.so.conf'
-  #       sudo ldconfig 
-  #       sudo ldconfig -v
+    - name: Add Dynamic libraries 
+      run: |
+        sudo sh -c 'echo "/lib/x86_64-linux-gnu/" >> /etc/ld.so.conf'
+        sudo sh -c 'echo "/lib64/" >> /etc/ld.so.conf'
+        sudo sh -c 'echo "/usr/local/lib/" >> /etc/ld.so.conf'
+        sudo ldconfig 
+        sudo ldconfig -v
 
-  #   - name: Linux script
-  #     run: |
-  #       cd sfont~
-  #       make PDLIBDIR=${{github.workspace}}/else-Linux/ localdep_linux
+    - name: Linux script
+      run: |
+        cd sfont~
+        make PDLIBDIR=${{github.workspace}}/else-Linux/ localdep_linux
         
-  #   - name: Compile Objects
-  #     run: make PDINCLUDEDIR=./pure-data/src/
+    - name: Compile Objects
+      run: make PDINCLUDEDIR=./pure-data/src/
 
-  #   - name: Create Library Folder
-  #     run: | 
-  #       cp *.pd_linux ./else-Linux
-  #       cp Help-files/* ./else-Linux
-  #       cp Classes/libpd-abs/* ./else-Linux
-  #       cp Classes/Abstractions/* ./else-Linux
-  #       cp Classes/Abs_components/* ./else-Linux
-  #       cp -r Live-Electronics-Tutorial ./else-Linux
-  #       cp extra/* ./else-Linux
-  #       cp README.pdf ./else-Linux
-  #       mv -v ./else-Linux/sfont~/* ./else-Linux/
-  #       rm -rf ./else-Linux/sfont~
+    - name: Create Library Folder
+      run: | 
+        cp *.pd_linux ./else-Linux
+        cp Help-files/* ./else-Linux
+        cp Classes/libpd-abs/* ./else-Linux
+        cp Classes/Abstractions/* ./else-Linux
+        cp Classes/Abs_components/* ./else-Linux
+        cp -r Live-Electronics-Tutorial ./else-Linux
+        cp extra/* ./else-Linux
+        cp README.pdf ./else-Linux
+        mv -v ./else-Linux/sfont~/* ./else-Linux/
+        rm -rf ./else-Linux/sfont~
         
-  #   - name: Upload Zip
-  #     uses: actions/upload-artifact@v3
-  #     with:
-  #       name: else-MAIN-LINUX64-Bits
-  #       path: ./else-Linux/*
+    - name: Upload Zip
+      uses: actions/upload-artifact@v3
+      with:
+        name: else-MAIN-LINUX64-Bits
+        path: ./else-Linux/*
+
+# ===============================================================
+# ===============================================================
+# ===============================================================
+
 
   Windows-Build:  
     runs-on: windows-latest
@@ -107,21 +112,32 @@ jobs:
         choco install puredata --yes
 
     - if: runner.os == 'Windows'
-      name: Build pd-else
-      shell: msys2 {0}
-      run: | 
-        PD_URL=$(curl -L -s https://api.github.com/repos/pure-data/pure-data/tags | grep zipball_url | grep -v latest | grep -v pd-0.52 | grep -v tagtest | head -n 1 | cut -d '"' -f 4)
-        curl -L -o pure-data.zip $PD_URL
-        unzip pure-data.zip
-        rm pure-data.zip
-        mv pure-data-* pure-data
-
-    - if: runner.os == 'Windows'
       name: Download and build FluidSynth
       shell: msys2 {0}
       run: | 
         mkdir ./else-Windows 
         cd sfont~
-        make 
+        make scripts/localdeps.win.sh
         cd .. 
         make 
+
+    - if: runner.os == 'Windows'
+      name: Create Library Folder
+      shell: msys2 {0}
+      run: |
+        cp *.dll ./else-Windows
+        cp Help-files/* ./else-Windows
+        cp Classes/libpd-abs/* ./else-Windows
+        cp Classes/Abstractions/* ./else-Windows
+        cp Classes/Abs_components/* ./else-Windows
+        cp -r Live-Electronics-Tutorial ./else-Windows
+        cp extra/* ./else-Windows
+        cp README.pdf ./else-Windows
+        mv -v ./else-Windows/sfont~/* ./else-Windows/
+        rm -rf ./else-Windows/sfont~
+
+    - name: Upload Zip
+      uses: actions/upload-artifact@v3
+      with:
+        name: else-WINDOWS64-Bits
+        path: ./else-Windows/*

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -128,7 +128,6 @@ jobs:
         make extension=m_amd64
         make localdep_windows
         cd ..
-        cp sfont~/* ./else-Windows
 
     - if: runner.os == 'Windows'
       name: Build pd-else
@@ -149,7 +148,7 @@ jobs:
         cp extra/* ./else-Windows
         cp README.pdf ./else-Windows
         mkdir ./else-Windows/sfont~
-        mv -v ./sfont~/* ./else-Windows/sfont~
+        cp -vr ./sfont~/* ./else-Windows/sfont~
 
     - name: Upload Zip
       uses: actions/upload-artifact@v3

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -47,8 +47,9 @@ jobs:
         sudo ldconfig -v
         sudo make install
         cd ../..
-        make PDINCLUDEDIR=${{github.workspace}}/pure-data/src
+        make 
         
+    # PDINCLUDEDIR=${{github.workspace}}/pure-data/src  
     - name: Add Dynamic libraries 
       run: |
         sudo sh -c 'echo "/lib/x86_64-linux-gnu/" >> /etc/ld.so.conf'
@@ -60,7 +61,7 @@ jobs:
     - name: Linux script
       run: |
         cd sfont~
-        make PDLIBDIR=${{github.workspace}}/else-Linux/ localdep_linux
+        make localdep_linux
         
     - name: Compile Objects
       run: make PDINCLUDEDIR=./pure-data/src/

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -98,7 +98,7 @@ jobs:
       name: "Install mingw deps"
       uses: msys2/setup-msys2@v2
       with:
-          install: make autoconf automake libtool mingw-w64-x86_64-gcc mingw64/mingw-w64-x86_64-ntldd-git libtool mingw-w64-x86_64-libwinpthread-git mingw-w64-x86_64-libsystre mingw-w64-x86_64-dlfcn  mingw-w64-x86_64-fluidsynth  mingw-w64-x86_64-grep
+          install: make autoconf automake libtool mingw-w64-x86_64-gcc mingw64/mingw-w64-x86_64-ntldd-git libtool mingw-w64-x86_64-libwinpthread-git mingw-w64-x86_64-libsystre mingw-w64-x86_64-dlfcn  mingw-w64-x86_64-fluidsynth  mingw-w64-x86_64-grep unzip
           update: false
 
     - name: Configure Environment
@@ -107,8 +107,8 @@ jobs:
         choco install puredata --yes
 
     - if: runner.os == 'Windows'
-      name: "Downloads pd-Sources"
-      uses: msys2/setup-msys2@v2
+      name: Build pd-else
+      shell: msys2 {0}
       run: | 
         PD_URL=$(curl -L -s https://api.github.com/repos/pure-data/pure-data/tags | grep zipball_url | grep -v latest | grep -v pd-0.52 | grep -v tagtest | head -n 1 | cut -d '"' -f 4)
         curl -L -o pure-data.zip $PD_URL
@@ -116,7 +116,9 @@ jobs:
         rm pure-data.zip
         mv pure-data-* pure-data
 
-    - name: Download and build FluidSynth
+    - if: runner.os == 'Windows'
+      name: Download and build FluidSynth
+      shell: msys2 {0}
       run: | 
         mkdir ./else-Windows 
         cd sfont~

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -9,13 +9,103 @@ on:
     paths-ignore: ['md-help/**', 'Help-files/**']
 
 jobs:
-  Linux-Build:
-    runs-on: ubuntu-latest
+  # Linux-Build:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - uses: actions/checkout@v3
+  #   - name: Install PureData
+  #     run: sudo apt-get install puredata -y 
 
+  #   - name: Downloads pd-Sources 
+  #     run: | 
+  #       PD_URL=$(curl -L -s https://api.github.com/repos/pure-data/pure-data/tags | grep zipball_url | grep -v latest | grep -v pd-0.52 | grep -v tagtest | head -n 1 | cut -d '"' -f 4)
+  #       curl -L -o pure-data.zip $PD_URL
+  #       unzip pure-data.zip
+  #       rm pure-data.zip
+  #       mv pure-data-* pure-data
+        
+  #   - name: Install FluidSynth deps
+  #     run: sudo apt install cmake libglib2.0-dev libpcre++-dev libsndfile1-dev patchelf -y
+
+  #   - name: Download and build FluidSynth
+  #     run: | 
+  #       mkdir ./else-Linux 
+  #       cd sfont~
+  #       URL=$(curl -L -s https://api.github.com/repos/FluidSynth/fluidsynth/releases/latest | grep zipball_url | cut -d '"' -f 4)
+  #       curl -L -o fluidsynth.zip $URL
+  #       unzip fluidsynth.zip
+  #       rm fluidsynth.zip
+  #       mv FluidSynth-* FluidSynth
+  #       cd FluidSynth
+  #       mkdir build
+  #       cd build
+  #       cmake -Denable-libsndfile=on -Denable-jack=off -Denable-alsa=off -Denable-oss=off -Denable-pulseaudio=off -Denable-ladspa=off -Denable-aufile=off -Denable-network=off -Denable-ipv6=off -Denable-getopt=off -Denable-sdl2=off -Denable-threads=off ..
+  #       sudo ldconfig /lib/x86_64-linux-gnu/
+  #       sudo ldconfig -v
+  #       sudo make install
+  #       cd ../..
+  #       make PDINCLUDEDIR=${{github.workspace}}/pure-data/src
+        
+  #   - name: Add Dynamic libraries 
+  #     run: |
+  #       sudo sh -c 'echo "/lib/x86_64-linux-gnu/" >> /etc/ld.so.conf'
+  #       sudo sh -c 'echo "/lib64/" >> /etc/ld.so.conf'
+  #       sudo sh -c 'echo "/usr/local/lib/" >> /etc/ld.so.conf'
+  #       sudo ldconfig 
+  #       sudo ldconfig -v
+
+  #   - name: Linux script
+  #     run: |
+  #       cd sfont~
+  #       make PDLIBDIR=${{github.workspace}}/else-Linux/ localdep_linux
+        
+  #   - name: Compile Objects
+  #     run: make PDINCLUDEDIR=./pure-data/src/
+
+  #   - name: Create Library Folder
+  #     run: | 
+  #       cp *.pd_linux ./else-Linux
+  #       cp Help-files/* ./else-Linux
+  #       cp Classes/libpd-abs/* ./else-Linux
+  #       cp Classes/Abstractions/* ./else-Linux
+  #       cp Classes/Abs_components/* ./else-Linux
+  #       cp -r Live-Electronics-Tutorial ./else-Linux
+  #       cp extra/* ./else-Linux
+  #       cp README.pdf ./else-Linux
+  #       mv -v ./else-Linux/sfont~/* ./else-Linux/
+  #       rm -rf ./else-Linux/sfont~
+        
+  #   - name: Upload Zip
+  #     uses: actions/upload-artifact@v3
+  #     with:
+  #       name: else-MAIN-LINUX64-Bits
+  #       path: ./else-Linux/*
+
+  Windows-Build:  
+    runs-on: windows-latest
+    if: ${{ github.event.inputs.Windows == 'true' }}
+    timeout-minutes: 15
     steps:
     - uses: actions/checkout@v3
-    - name: Install PureData
-      run: sudo apt-get install puredata -y 
+      with:
+        submodules: recursive
+        fetch-depth: 0
+
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+
+    - if: runner.os == 'Windows'
+      name: "Install mingw deps"
+      uses: msys2/setup-msys2@v2
+      with:
+          install: make autoconf automake libtool mingw-w64-x86_64-gcc mingw64/mingw-w64-x86_64-ntldd-git libtool mingw-w64-x86_64-libwinpthread-git mingw-w64-x86_64-libsystre mingw-w64-x86_64-dlfcn pacman -S mingw-w64-x86_64-fluidsynth pacman -S mingw-w64-x86_64-grep
+          update: false
+
+    - name: Configure Environment
+      run: |
+        mkdir py4pd_WIN64
+        choco install puredata --yes
 
     - name: Downloads pd-Sources 
       run: | 
@@ -24,15 +114,10 @@ jobs:
         unzip pure-data.zip
         rm pure-data.zip
         mv pure-data-* pure-data
-        
-        
-
-    - name: Install FluidSynth deps
-      run: sudo apt install cmake libglib2.0-dev libpcre++-dev libsndfile1-dev patchelf -y
 
     - name: Download and build FluidSynth
       run: | 
-        mkdir ./else-Linux 
+        mkdir ./else-Windows 
         cd sfont~
         URL=$(curl -L -s https://api.github.com/repos/FluidSynth/fluidsynth/releases/latest | grep zipball_url | cut -d '"' -f 4)
         curl -L -o fluidsynth.zip $URL
@@ -43,47 +128,6 @@ jobs:
         mkdir build
         cd build
         cmake -Denable-libsndfile=on -Denable-jack=off -Denable-alsa=off -Denable-oss=off -Denable-pulseaudio=off -Denable-ladspa=off -Denable-aufile=off -Denable-network=off -Denable-ipv6=off -Denable-getopt=off -Denable-sdl2=off -Denable-threads=off ..
-        sudo ldconfig /lib/x86_64-linux-gnu/
-        sudo ldconfig -v
-        sudo make install
-
-
-    - name: Make Else
-      run: | 
         make 
-
-    # PDINCLUDEDIR=${{github.workspace}}/pure-data/src  
-    - name: Add Dynamic libraries 
-      run: |
-        sudo sh -c 'echo "/lib/x86_64-linux-gnu/" >> /etc/ld.so.conf'
-        sudo sh -c 'echo "/lib64/" >> /etc/ld.so.conf'
-        sudo sh -c 'echo "/usr/local/lib/" >> /etc/ld.so.conf'
-        sudo ldconfig 
-        sudo ldconfig -v
-
-    - name: Linux script
-      run: |
-        cd sfont~
-        make localdep_linux
-        
-    - name: Compile Objects
-      run: make PDINCLUDEDIR=./pure-data/src/
-
-    - name: Create Library Folder
-      run: | 
-        cp *.pd_linux ./else-Linux
-        cp Help-files/* ./else-Linux
-        cp Classes/libpd-abs/* ./else-Linux
-        cp Classes/Abstractions/* ./else-Linux
-        cp Classes/Abs_components/* ./else-Linux
-        cp -r Live-Electronics-Tutorial ./else-Linux
-        cp extra/* ./else-Linux
-        cp README.pdf ./else-Linux
-        mv -v ./else-Linux/sfont~/* ./else-Linux/
-        rm -rf ./else-Linux/sfont~
-        
-    # - name: Upload Zip
-    #   uses: actions/upload-artifact@v3
-    #   with:
-    #     name: else-MAIN-LINUX64-Bits
-    #     path: ./else-Linux/*
+        cd ../..
+        make PDINCLUDEDIR=${{github.workspace}}/pure-data/src

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -98,7 +98,7 @@ jobs:
       name: "Install mingw deps"
       uses: msys2/setup-msys2@v2
       with:
-          install: make autoconf automake libtool mingw-w64-x86_64-gcc mingw64/mingw-w64-x86_64-ntldd-git libtool mingw-w64-x86_64-libwinpthread-git mingw-w64-x86_64-libsystre mingw-w64-x86_64-dlfcn pacman -S mingw-w64-x86_64-fluidsynth pacman -S mingw-w64-x86_64-grep
+          install: make autoconf automake libtool mingw-w64-x86_64-gcc mingw64/mingw-w64-x86_64-ntldd-git libtool mingw-w64-x86_64-libwinpthread-git mingw-w64-x86_64-libsystre mingw-w64-x86_64-dlfcn  mingw-w64-x86_64-fluidsynth  mingw-w64-x86_64-grep
           update: false
 
     - name: Configure Environment

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -46,9 +46,12 @@ jobs:
         sudo ldconfig /lib/x86_64-linux-gnu/
         sudo ldconfig -v
         sudo make install
-        cd ../..
+
+
+    - name: Make Else
+      run: | 
         make 
-        
+
     # PDINCLUDEDIR=${{github.workspace}}/pure-data/src  
     - name: Add Dynamic libraries 
       run: |
@@ -79,8 +82,8 @@ jobs:
         mv -v ./else-Linux/sfont~/* ./else-Linux/
         rm -rf ./else-Linux/sfont~
         
-    - name: Upload Zip
-      uses: actions/upload-artifact@v3
-      with:
-        name: else-MAIN-LINUX64-Bits
-        path: ./else-Linux/*
+    # - name: Upload Zip
+    #   uses: actions/upload-artifact@v3
+    #   with:
+    #     name: else-MAIN-LINUX64-Bits
+    #     path: ./else-Linux/*

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -126,9 +126,16 @@ jobs:
         mkdir ./else-Windows 
         cd sfont~
         make extension=m_amd64
-        make localdep_windows
+        ./scripts/localdeps.win.sh sfont~.m_amd64
         cd ..
-
+    
+    - if: runner.os == 'Windows'
+      name: Build plaits~
+      shell: msys2 {0}
+      run: | 
+        cd plaits~
+        make extension=m_amd64
+        
     - if: runner.os == 'Windows'
       name: Build pd-else
       shell: msys2 {0}
@@ -145,10 +152,11 @@ jobs:
         cp Classes/Abstractions/* ./else-Windows
         cp Classes/Abs_components/* ./else-Windows
         cp -r Live-Electronics-Tutorial ./else-Windows
+        cp plaits~/*.m_amd64 ./else-Windows
         cp extra/* ./else-Windows
         cp README.pdf ./else-Windows
-        mkdir ./else-Windows/sfont~
-        cp -vr ./sfont~/* ./else-Windows/sfont~
+        cp -vr ./sfont~/* ./else-Windows/
+        cd else-Windows
 
     - name: Upload Zip
       uses: actions/upload-artifact@v3

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -9,6 +9,10 @@ on:
     paths-ignore: ['md-help/**', 'Help-files/**']
 
 jobs:
+
+# ===============================================================
+# ===============================================================
+# ===============================================================
   Linux-Build:
     runs-on: ubuntu-latest
     steps:
@@ -23,7 +27,7 @@ jobs:
         unzip pure-data.zip
         rm pure-data.zip
         mv pure-data-* pure-data
-        
+
     - name: Install FluidSynth deps
       run: sudo apt install cmake libglib2.0-dev libpcre++-dev libsndfile1-dev patchelf -y
 
@@ -54,10 +58,15 @@ jobs:
         sudo ldconfig 
         sudo ldconfig -v
 
-    - name: Linux script
+    - name: Build sfont~
       run: |
         cd sfont~
         make PDLIBDIR=${{github.workspace}}/else-Linux/ localdep_linux
+
+    - name: Build plaits~
+      run: |
+
+
         
     - name: Compile Objects
       run: make PDINCLUDEDIR=./pure-data/src/
@@ -85,7 +94,6 @@ jobs:
 # ===============================================================
 # ===============================================================
 
-
   Windows-Build:  
     runs-on: windows-latest
     timeout-minutes: 15
@@ -112,20 +120,26 @@ jobs:
         choco install puredata --yes
 
     - if: runner.os == 'Windows'
-      name: Download and build FluidSynth
+      name: Build sfont
       shell: msys2 {0}
       run: | 
         mkdir ./else-Windows 
         cd sfont~
-        make scripts/localdeps.win.sh
-        cd .. 
-        make 
+        make scripts/localdeps.win.sh extension=m_amd64
+        cd ..
+        cp sfont~/* ./else-Windows
+
+    - if: runner.os == 'Windows'
+      name: Build pd-else
+      shell: msys2 {0}
+      run: |
+        make extension=m_amd64 
 
     - if: runner.os == 'Windows'
       name: Create Library Folder
       shell: msys2 {0}
       run: |
-        cp *.dll ./else-Windows
+        cp *.m_amd64 ./else-Windows
         cp Help-files/* ./else-Windows
         cp Classes/libpd-abs/* ./else-Windows
         cp Classes/Abstractions/* ./else-Windows
@@ -133,11 +147,15 @@ jobs:
         cp -r Live-Electronics-Tutorial ./else-Windows
         cp extra/* ./else-Windows
         cp README.pdf ./else-Windows
-        mv -v ./else-Windows/sfont~/* ./else-Windows/
-        rm -rf ./else-Windows/sfont~
+        mkdir ./else-Windows/sfont~
+        mv -v ./sfont~/* ./else-Windows/sfont~
 
     - name: Upload Zip
       uses: actions/upload-artifact@v3
       with:
         name: else-WINDOWS64-Bits
         path: ./else-Windows/*
+
+# ===============================================================
+# ===============================================================
+# ===============================================================

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -153,11 +153,11 @@ jobs:
         cp Classes/Abs_components/* ./else-Windows
         cp -r Live-Electronics-Tutorial ./else-Windows
         cp plaits~/*.m_amd64 ./else-Windows
+        cp sfont~/*.m_amd64 ./else-Windows
+        ./sfont~/scripts/localdeps.win.sh ./else-Windows/sfont~.m_amd64
         cp extra/* ./else-Windows
         cp README.pdf ./else-Windows
-        cp -vr ./sfont~/* ./else-Windows/
-        cd else-Windows
-
+        
     - name: Upload Zip
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -83,7 +83,6 @@ jobs:
 
   Windows-Build:  
     runs-on: windows-latest
-    if: ${{ github.event.inputs.Windows == 'true' }}
     timeout-minutes: 15
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -122,15 +122,6 @@ jobs:
       run: | 
         mkdir ./else-Windows 
         cd sfont~
-        URL=$(curl -L -s https://api.github.com/repos/FluidSynth/fluidsynth/releases/latest | grep zipball_url | cut -d '"' -f 4)
-        curl -L -o fluidsynth.zip $URL
-        unzip fluidsynth.zip
-        rm fluidsynth.zip
-        mv FluidSynth-* FluidSynth
-        cd FluidSynth
-        mkdir build
-        cd build
-        cmake -Denable-libsndfile=on -Denable-jack=off -Denable-alsa=off -Denable-oss=off -Denable-pulseaudio=off -Denable-ladspa=off -Denable-aufile=off -Denable-network=off -Denable-ipv6=off -Denable-getopt=off -Denable-sdl2=off -Denable-threads=off ..
         make 
         cd ../..
         make PDINCLUDEDIR=${{github.workspace}}/pure-data/src

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -120,7 +120,7 @@ jobs:
         choco install puredata --yes
 
     - if: runner.os == 'Windows'
-      name: Build sfont
+      name: Build sfont~
       shell: msys2 {0}
       run: | 
         mkdir ./else-Windows 
@@ -151,10 +151,12 @@ jobs:
         cp Classes/libpd-abs/* ./else-Windows
         cp Classes/Abstractions/* ./else-Windows
         cp Classes/Abs_components/* ./else-Windows
+        mkdir ./else-Windows/sf
+        cp sfont~/sf/* ./else-Windows/sf
         cp -r Live-Electronics-Tutorial ./else-Windows
         cp plaits~/*.m_amd64 ./else-Windows
         cp sfont~/*.m_amd64 ./else-Windows
-        ./sfont~/scripts/localdeps.win.sh ./else-Windows/sfont~.m_amd64
+        cp sfont~/sfont-compiled/*.w64 ./else-Windows
         cp extra/* ./else-Windows
         cp README.pdf ./else-Windows
         
@@ -167,3 +169,5 @@ jobs:
 # ===============================================================
 # ===============================================================
 # ===============================================================
+
+

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -106,7 +106,9 @@ jobs:
         mkdir py4pd_WIN64
         choco install puredata --yes
 
-    - name: Downloads pd-Sources 
+    - if: runner.os == 'Windows'
+      name: "Downloads pd-Sources"
+      uses: msys2/setup-msys2@v2
       run: | 
         PD_URL=$(curl -L -s https://api.github.com/repos/pure-data/pure-data/tags | grep zipball_url | grep -v latest | grep -v pd-0.52 | grep -v tagtest | head -n 1 | cut -d '"' -f 4)
         curl -L -o pure-data.zip $PD_URL

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -88,7 +88,7 @@ jobs:
     - name: Upload Zip
       uses: actions/upload-artifact@v3
       with:
-        name: else-MAIN-LINUX64-Bits
+        name: else
         path: ./else-Linux/*
 
 # ===============================================================
@@ -164,7 +164,7 @@ jobs:
     - name: Upload Zip
       uses: actions/upload-artifact@v3
       with:
-        name: else-WINDOWS64-Bits
+        name: else
         path: ./else-Windows/*
 
 # ===============================================================

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -125,7 +125,8 @@ jobs:
       run: | 
         mkdir ./else-Windows 
         cd sfont~
-        make scripts/localdeps.win.sh extension=m_amd64
+        make extension=m_amd64
+        make localdep_windows
         cd ..
         cp sfont~/* ./else-Windows
 


### PR DESCRIPTION
Opa,

Isso adiciona os objetos para Windows 64bits também. Agora, os objetos de Linux 64bits e Windows 64bits são salvos no artefato gerado.

Pessoal usa windows 32 bits ainda? Acho que não né. 

