### PR TITLE
Fix [ramp~] crashing when min > max

### DIFF
--- a/Classes/Source/ramp~.c
+++ b/Classes/Source/ramp~.c
@@ -99,6 +99,7 @@ static t_int *ramp_perform(t_int *w){
                     temp = max;
                     max = min;
                     min = temp;
+                    range = max - min;
                 };
                 if(x->x_mode == 0){ // loop
                     x->x_clip = 0;


### PR DESCRIPTION
When we swap min/max, we also need to recalculate range, otherwise it will be negative and:

```
while(phase >= max)
  phase -= range;
```

will loop forever.