### PR TITLE
removed nonspace whitespaces in plaits~/Makefile; edited plaits~/pd-l…

### DIFF
--- a/plaits~/Makefile
+++ b/plaits~/Makefile
@@ -7,7 +7,7 @@ common.sources = stmlib/dsp/units.cc \
                  plaits/dsp/voice.cc \
                  plaits/dsp/engine/additive_engine.cc \
                  plaits/dsp/engine/bass_drum_engine.cc \
-                 plaits/dsp/engine/chord_engine.cc \
+                 plaits/dsp/engine/chord_engine.cc \
                  plaits/dsp/engine/fm_engine.cc \
                  plaits/dsp/engine/grain_engine.cc \
                  plaits/dsp/engine/hi_hat_engine.cc \
@@ -18,7 +18,7 @@ common.sources = stmlib/dsp/units.cc \
                  plaits/dsp/engine/speech_engine.cc \
                  plaits/dsp/engine/string_engine.cc \
                  plaits/dsp/engine/swarm_engine.cc \
-                 plaits/dsp/engine/virtual_analog_engine.cc \
+                 plaits/dsp/engine/virtual_analog_engine.cc \
                  plaits/dsp/engine/waveshaping_engine.cc \
                  plaits/dsp/engine/wavetable_engine.cc \
                  plaits/dsp/speech/lpc_speech_synth.cc \

--- a/plaits~/pd-lib-builder/Makefile.pdlibbuilder
+++ b/plaits~/pd-lib-builder/Makefile.pdlibbuilder
@@ -522,7 +522,7 @@ ifeq ($(system), Darwin)
     cxx.flags := -fcheck-new
   endif
   ifeq ($(extension), d_fat)
-    arch := i386 x86_64
+    arch := i386 x86_64 arm64
   else
     arch := $(target.arch)
   endif


### PR DESCRIPTION
…ib-builder/Makefile.pdlibbuilder to allow compilation for i386 + x86_64 + arm64 on macOS