### PR TITLE
Add workflow_dispatch

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,6 +1,7 @@
 name: C/C++ CI
 
 on:
+  workflow_dispatch:
   push:
     branches: [ "master", "CI"]
     paths-ignore: ['md-help/**']


### PR DESCRIPTION
Add the necessary `workflow_dispatch` trigger to the workflow so that you can manually trigger a build on a branch of your choice; see https://build5nines.com/configuring-manual-triggers-in-github-actions-with-workflow_dispatch/.

This is *very* convenient if you work a lot with different feature branches as I do, especially when preparing a pull request. Instead of having to add each and every such branch to the workflow triggers, you can then just go to the workflow on the Actions tab in the web interface, press the "Run workflow" button, and choose the branch you want to be built.