### PR TITLE
Allow p/n/u/m/k suffixes for values. Enable build optimisations, copy built external to ELSE's root dir

### DIFF
--- a/Code_source/Compiled/audio/circuit~/Source/Simulator.cpp
+++ b/Code_source/Compiled/audio/circuit~/Source/Simulator.cpp
@@ -26,8 +26,26 @@ int getPinValue(std::string arg) {
     return result;
 }
 
+std::string replaceString(std::string subject, const std::string& search,
+                          const std::string& replace) {
+    size_t pos = 0;
+    while((pos = subject.find(search, pos)) != std::string::npos) {
+         subject.replace(pos, search.length(), replace);
+         pos += replace.length();
+    }
+    return subject;
+}
+
+
 double getArgumentValue(std::string arg) {
     double result = 0.0f;
+    
+    arg = replaceString(arg, "p", "e-12");
+    arg = replaceString(arg, "n", "e-9");
+    arg = replaceString(arg, "u", "e-6");
+    arg = replaceString(arg, "m", "e-3");
+    arg = replaceString(arg, "k", "e3");
+    
     try {
         result = std::stod(arg);
     } catch (...) {

--- a/Code_source/Compiled/audio/circuit~/build.sh
+++ b/Code_source/Compiled/audio/circuit~/build.sh
@@ -2,6 +2,6 @@
 
 mkdir -p build
 cd build
-cmake ..
+cmake -DCMAKE_BUILD_TYPE="Release" ..
 cmake --build .
 cp ../binaries/* ../../../../../

--- a/Code_source/Compiled/audio/circuit~/build.sh
+++ b/Code_source/Compiled/audio/circuit~/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-
 mkdir -p build
 cd build
 cmake ..
-make
+cmake --build .
+cp ../binaries/* ../../../../../


### PR DESCRIPTION
This runs a lot faster now, optimisations were disabled before. Also, quite nice to enter 0.01u for capacitor values instead of 0.01e-6.