### PR TITLE
Fix some memory issues

### DIFF
--- a/Code_source/Compiled/audio/allpass.rev~.c
+++ b/Code_source/Compiled/audio/allpass.rev~.c
@@ -194,8 +194,8 @@ static void *allpass_rev_new(t_symbol *s, int argc, t_atom *argv){
     x->x_xbuf = x->x_ffstack;
     allpass_rev_clear(x);
 /////////////////////////////////////////////////////////////////////////////////////
-    float init_maxdelay;
-    float init_coeff;
+    float init_maxdelay = 0.0f;
+    float init_coeff = 0.0f;
     int argnum = 0;
     while(argc > 0){
         if(argv -> a_type == A_FLOAT){ //if current argument is a float

--- a/Code_source/Compiled/control/bend.in.c
+++ b/Code_source/Compiled/control/bend.in.c
@@ -86,7 +86,7 @@ static void bendin_free(t_bendin *x){
     pd_unbind(&x->x_obj.ob_pd, gensym("#midiin"));
 }
 
-static void *bendin_new(t_symbol *s, t_int ac, t_atom *av){
+static void *bendin_new(t_symbol *s, int ac, t_atom *av){
     t_bendin *x = (t_bendin *)pd_new(bendin_class);
     t_symbol *curarg = s; // get rid of warning
     t_int channel = 0;

--- a/Code_source/Compiled/control/bend.out.c
+++ b/Code_source/Compiled/control/bend.out.c
@@ -41,7 +41,7 @@ static void bendout_float(t_bendout *x, t_float f){
     }
 }
 
-static void *bendout_new(t_symbol *s, t_int ac, t_atom *av){
+static void *bendout_new(t_symbol *s, int ac, t_atom *av){
     t_bendout *x = (t_bendout *)pd_new(bendout_class);
     t_symbol *curarg = s; // get rid of warning
     floatinlet_new((t_object *)x, &x->x_channel);

--- a/Code_source/Compiled/control/ctl.in.c
+++ b/Code_source/Compiled/control/ctl.in.c
@@ -89,7 +89,7 @@ static void ctlin_free(t_ctlin *x){
     pd_unbind(&x->x_obj.ob_pd, gensym("#midiin"));
 }
 
-static void *ctlin_new(t_symbol *s, t_int ac, t_atom *av){
+static void *ctlin_new(t_symbol *s, int ac, t_atom *av){
     t_ctlin *x = (t_ctlin *)pd_new(ctlin_class);
     t_symbol *curarg = NULL;
     curarg = s; // get rid of warning

--- a/Code_source/Compiled/control/ctl.out.c
+++ b/Code_source/Compiled/control/ctl.out.c
@@ -42,7 +42,7 @@ static void ctlout_float(t_ctlout *x, t_float f){
     }
 }
 
-static void *ctlout_new(t_symbol *s, t_int ac, t_atom *av){
+static void *ctlout_new(t_symbol *s, int ac, t_atom *av){
     s = NULL;
     t_ctlout *x = (t_ctlout *)pd_new(ctlout_class);
     x->x_channel = 1,

--- a/Code_source/Compiled/control/note.in.c
+++ b/Code_source/Compiled/control/note.in.c
@@ -130,7 +130,7 @@ static void notein_free(t_notein *x){
     pd_unbind(&x->x_obj.ob_pd, gensym("#midiin"));
 }
 
-static void *notein_new(t_symbol *s, t_int ac, t_atom *av){
+static void *notein_new(t_symbol *s, int ac, t_atom *av){
     t_notein *x = (t_notein *)pd_new(notein_class);
     t_symbol *curarg = NULL;
     curarg = s; // get rid of warning

--- a/Code_source/Compiled/control/note.out.c
+++ b/Code_source/Compiled/control/note.out.c
@@ -75,7 +75,7 @@ static void noteout_float(t_noteout *x, t_float f){
     }
 }
 
-static void *noteout_new(t_symbol *s, t_int ac, t_atom *av){
+static void *noteout_new(t_symbol *s, int ac, t_atom *av){
     t_noteout *x = (t_noteout *)pd_new(noteout_class);
     s = NULL; // get rid of warning
     float channel = 1;

--- a/Code_source/Compiled/control/pgm.in.c
+++ b/Code_source/Compiled/control/pgm.in.c
@@ -60,7 +60,7 @@ static void pgmin_free(t_pgmin *x){
     pd_unbind(&x->x_obj.ob_pd, gensym("#midiin"));
 }
 
-static void *pgmin_new(t_symbol *s, t_int ac, t_atom *av){
+static void *pgmin_new(t_symbol *s, int ac, t_atom *av){
     s = NULL;
     t_pgmin *x = (t_pgmin *)pd_new(pgmin_class);
     x->x_pgm = 0;

--- a/Code_source/Compiled/control/pgm.in.c
+++ b/Code_source/Compiled/control/pgm.in.c
@@ -87,7 +87,7 @@ static void *pgmin_new(t_symbol *s, int ac, t_atom *av){
 
 void setup_pgm0x2ein(void){
     pgmin_class = class_new(gensym("pgm.in"), (t_newmethod)pgmin_new,
-        (t_method)pgmin_free, sizeof(t_pgmin), 0, A_DEFFLOAT, 0);
+        (t_method)pgmin_free, sizeof(t_pgmin), 0, A_GIMME, 0);
     class_addfloat(pgmin_class, pgmin_float);
     class_addlist(pgmin_class, pgmin_list);
     class_addmethod(pgmin_class, (t_method)pgmin_ext, gensym("ext"), A_DEFFLOAT, 0);

--- a/Code_source/Compiled/control/pgm.out.c
+++ b/Code_source/Compiled/control/pgm.out.c
@@ -35,7 +35,7 @@ static void pgmout_float(t_pgmout *x, t_float f){
     }
 }
 
-static void *pgmout_new(t_symbol *s, t_int ac, t_atom *av){
+static void *pgmout_new(t_symbol *s, int ac, t_atom *av){
     t_pgmout *x = (t_pgmout *)pd_new(pgmout_class);
     t_symbol *curarg = NULL;
     curarg = s; // get rid of warning

--- a/Code_source/Compiled/control/ptouch.in.c
+++ b/Code_source/Compiled/control/ptouch.in.c
@@ -106,7 +106,7 @@ static void *ptouchin_new(t_symbol *s, int ac, t_atom *av){
 
 void setup_ptouch0x2ein(void){
     ptouchin_class = class_new(gensym("ptouch.in"), (t_newmethod)ptouchin_new,
-        (t_method)ptouchin_free, sizeof(t_ptouchin), 0, A_DEFFLOAT, 0);
+        (t_method)ptouchin_free, sizeof(t_ptouchin), 0, A_GIMME, 0);
     class_addfloat(ptouchin_class, ptouchin_float);
     class_addlist(ptouchin_class, ptouchin_list);
     class_addmethod(ptouchin_class, (t_method)ptouchin_ext, gensym("ext"), A_DEFFLOAT, 0);

--- a/Code_source/Compiled/control/ptouch.in.c
+++ b/Code_source/Compiled/control/ptouch.in.c
@@ -82,7 +82,7 @@ static void ptouchin_free(t_ptouchin *x){
     pd_unbind(&x->x_obj.ob_pd, gensym("#midiin"));
 }
 
-static void *ptouchin_new(t_symbol *s, t_int ac, t_atom *av){
+static void *ptouchin_new(t_symbol *s, int ac, t_atom *av){
     s = NULL;
     t_ptouchin *x = (t_ptouchin *)pd_new(ptouchin_class);
     x->x_ptouch =  x->x_ready = x->x_key = 0;

--- a/Code_source/Compiled/control/ptouch.out.c
+++ b/Code_source/Compiled/control/ptouch.out.c
@@ -38,7 +38,7 @@ static void ptouchout_float(t_ptouchout *x, t_float f){
     }
 }
 
-static void *ptouchout_new(t_symbol *s, t_int ac, t_atom *av){
+static void *ptouchout_new(t_symbol *s, int ac, t_atom *av){
     s = NULL;
     t_ptouchout *x = (t_ptouchout *)pd_new(ptouchout_class);
     t_float channel = 1;

--- a/Code_source/Compiled/control/touch.in.c
+++ b/Code_source/Compiled/control/touch.in.c
@@ -62,7 +62,7 @@ static void touchin_free(t_touchin *x){
     pd_unbind(&x->x_obj.ob_pd, gensym("#midiin"));
 }
 
-static void *touchin_new(t_symbol *s, t_int ac, t_atom *av){
+static void *touchin_new(t_symbol *s, int ac, t_atom *av){
     s = NULL;
     t_touchin *x = (t_touchin *)pd_new(touchin_class);
     x->x_atouch =  x->x_ready = x->x_pressure = 0;


### PR DESCRIPTION
Pd needs the argument count for an object to be of type "int" instead of "t_int". If they happen to have the same size, you won't notice it, but otherwise it will crash.

Also, some variables in allpass.rev~ were used without initialisation.