### PR TITLE
Bugfixes for pdlua and [circle]

### DIFF
--- a/Code_source/Abstractions/control/circle.pd
+++ b/Code_source/Abstractions/control/circle.pd
@@ -110,14 +110,15 @@
 #X msg 570 -200 -1;
 #X obj -317 0 symbol;
 #X obj -244 0 symbol;
+#X obj 274 177 change 127;
 #X connect 0 0 37 0;
-#X connect 3 0 32 0;
+#X connect 3 0 61 0;
 #X connect 4 0 5 0;
 #X connect 5 0 9 0;
 #X connect 5 0 31 0;
 #X connect 5 0 41 0;
 #X connect 6 0 34 0;
-#X connect 7 0 32 0;
+#X connect 7 0 61 0;
 #X connect 8 0 10 0;
 #X connect 9 0 7 0;
 #X connect 10 0 42 0;
@@ -125,7 +126,7 @@
 #X connect 11 1 4 0;
 #X connect 13 0 59 0;
 #X connect 13 1 60 0;
-#X connect 14 0 32 0;
+#X connect 14 0 61 0;
 #X connect 15 0 10 0;
 #X connect 18 0 35 0;
 #X connect 20 0 19 1;
@@ -175,4 +176,5 @@
 #X connect 58 0 50 1;
 #X connect 59 0 17 0;
 #X connect 60 0 16 0;
+#X connect 61 0 32 0;
 #X coords 0 127 127 0 127 127 2 0 0;

--- a/Code_source/Abstractions/extra_abs/circle-gui.pd_lua
+++ b/Code_source/Abstractions/extra_abs/circle-gui.pd_lua
@@ -34,20 +34,19 @@ end
 
 function circle:mouse_down(x, y)
     local width, height = self:get_size()
+
+    if self.jump == 1 then
+        self.slider_position_x = (x / width)
+        self.slider_position_y = (y / height)
+    end
+
     self.mouse_down_x = x
     self.mouse_down_y = y
     self.last_mouse_x = x
     self.last_mouse_y = y
     self.mouse_down_slider_x = self.slider_position_x * width
     self.mouse_down_slider_y = self.slider_position_y * height
-
-    if self.jump == 1 then
-        self.slider_position_x = x
-        self.slider_position_y = y
-        self.mouse_down_slider_x = x
-        self.mouse_down_slider_y = y
-        self:repaint()
-    end
+    self:repaint()
 end
 
 function circle:mouse_drag(x, y)
@@ -182,7 +181,7 @@ end
 function circle:in_1_bang()
     local x = self:scale_value(self.slider_position_x, self.x_range_start, self.x_range_end)
     local y = self:scale_value(self.slider_position_y, self.y_range_start, self.y_range_end)
-    self:outlet(1, "list", {x, y})
+    self:outlet(1, "list", {x, -y})
 end
 
 function circle:in_1_list(atoms)

--- a/Code_source/Compiled/control/lua/pd.lua
+++ b/Code_source/Compiled/control/lua/pd.lua
@@ -472,6 +472,7 @@ function pd.Class:get_class() -- accessor for t_class*
   return self._class or nil
 end
 
+
 local lua = pd.Class:new():register("lua")  -- global controls (the [pdlua] object only)
 
 function lua:initialize(sel, atoms)
@@ -570,7 +571,6 @@ function lua:initialize(sel, atoms)
 
   return true
 end
-
 
 function lua:dsp(sample_rate, block_size)
     local m = _G[self.function_prefix .. "dsp"]

--- a/Code_source/Compiled/control/lua/pdlua_gfx.h
+++ b/Code_source/Compiled/control/lua/pdlua_gfx.h
@@ -695,7 +695,9 @@ static int set_size(lua_State* L)
     obj->gfx.width = luaL_checknumber(L, 2);
     obj->gfx.height = luaL_checknumber(L, 3);
     pdlua_gfx_repaint(obj, 0);
-    canvas_fixlinesfor(obj->canvas, (t_text*)obj);
+    if(glist_isvisible(obj->canvas) && gobj_shouldvis(&obj->pd.te_g, obj->canvas)) {
+        canvas_fixlinesfor(obj->canvas, (t_text*)obj);
+    }
     return 0;
 }
 


### PR DESCRIPTION
This is part 1, I'll send more fixes tomorrow.

This one fixes:
- [pdlua] could call canvas_fixlinesfor on an invisible graph, which caused error messages
- Fixed jump mode implementation for [circle]
- Fixed flipped y range for [circle]
- Partially fixed the dialog asking to save, I'll test this more tomorrow