### PR TITLE
Bugfixes and band-limited oscillators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,12 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 set(CMAKE_MACOSX_RPATH ON)
+
+option(ENABLE_OPUS "Enable opus for pdlink~ stream compression" ON)
+if(!ENABLE_OPUS)
+  add_compile_definitions(ENABLE_OPUS=0)
+endif()
+
 if(UNIX AND NOT APPLE)
     set(CMAKE_BUILD_RPATH "$ORIGIN")
     set(CMAKE_INSTALL_RPATH "$ORIGIN")

--- a/Source/Audio/beat~.c
+++ b/Source/Audio/beat~.c
@@ -36,7 +36,7 @@ static const char* modelLabels[9] ={
 };
 
 void beat_mode(t_beat *x, t_floatarg f){
-    x->x_mode = f < 0 ? 0 : f > 9 ? 9 : (int)f;
+    x->x_mode = f < 0 ? 0 : f > 8 ? 8 : (int)f;
     x->x_t = new_aubio_tempo(modelLabels[x->x_mode],
         x->x_wsize, x->x_hopsize, x->x_sr);
     post("[beat~] mode = %s", modelLabels[x->x_mode]);
@@ -59,12 +59,16 @@ void beat_hop(t_beat *x, t_floatarg f){
 }
 
 void beat_thresh(t_beat *x, t_floatarg f){
-    float thresh = (f < 0.01) ? 0.01 : (f > 1.) ? 1. : f;
-    aubio_tempo_set_threshold(x->x_t, thresh);
+    if(x->x_t) {
+        float thresh = (f < 0.01) ? 0.01 : (f > 1.) ? 1. : f;
+        aubio_tempo_set_threshold(x->x_t, thresh);
+    }
 }
 
 void beat_silence(t_beat *x, t_floatarg f){
-    aubio_tempo_set_silence(x->x_t, f);
+    if(x->x_t) {
+        aubio_tempo_set_silence(x->x_t, f);
+    }
 }
 
 static t_int *beat_perform(t_int *w){
@@ -91,7 +95,9 @@ static void beat_dsp(t_beat *x, t_signal **sp){
 }
 
 static void beat_free(t_beat *x){
-    del_aubio_tempo(x->x_t);
+    if(x->x_t) {
+        del_aubio_tempo(x->x_t);
+    }
     del_fvec(x->x_out);
     del_fvec(x->x_vec);
 }

--- a/Source/Audio/bl.imp2~.c
+++ b/Source/Audio/bl.imp2~.c
@@ -1,586 +1,86 @@
+// Created by Timothy Schoen and Porres
+// Based on Elliptic BLEP by signalsmith-audio: https://github.com/Signalsmith-Audio/elliptic-blep
 
 #include <m_pd.h>
+#include <blep.h>
 
-#define _USE_MATH_DEFINES
+typedef struct blimp{
+    t_object    x_obj;
+    t_float     x_f;
+    t_elliptic_blep x_elliptic_blep;
+    t_float     x_phase;
+    t_int       x_direction;
+    t_float     x_sr;
+    t_int       x_midi;
+}t_blimp;
 
-#include <math.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <complex.h>
+t_class *blimp2_class;
 
-#if _MSC_VER
-#define t_complex _Dcomplex
-#ifndef CMPLX
-#define CMPLX(re,im) (t_complex){re,im}
-#endif
-#else
-#define t_complex complex double
-#ifdef __MINGW32__
-// mingw apparently lacks this macro in complex.h
-#ifndef CMPLX
-#define CMPLX(x, y) __builtin_complex ((double) (x), (double) (y))
-#endif
-#endif
-#endif
-
-// TODO: some of these aren't used
-#define LPHASOR      (8*sizeof(uint32_t)) // the phasor logsize
-#define VOICES       8 // the number of waveform voices
-#define LLENGTH      6 // the loglength of a fractional delayed basic waveform
-#define LOVERSAMPLE  6 // the log of the oversampling factor (nb of fract delayed waveforms)
-#define LPAD         1 // the log of the time padding factor (to reduce time aliasing)
-#define LTABLE       (LLENGTH+LOVERSAMPLE)
-#define N            (1<<LTABLE)
-#define M            (1<<(LTABLE+LPAD))
-#define S            (1<<LOVERSAMPLE)
-#define L            (1<<LLENGTH)
-#define CUTOFF       0.8 // fraction of nyquist for impulse cutoff
-#define NBPERIODS    ((t_float)(L) * CUTOFF / 2.0)
-//#define LMASK        (L-1)
-//#define WALPHA       0.1 // windowing alpha (0 = cos -> 1 = rect)
-
-// sample buffers
-static t_float bli[N]; // band limited impulse
-static t_float bls[N]; // band limited step
-//static t_float blr[N]; // band limited ramp
-
-t_class *blosc_class;
-
-typedef struct _butter_state{
-    // state data
-    t_float d1A;
-    t_float d2A;
-    t_float d1B;
-    t_float d2B;
-    // pole data
-    t_float ai;
-    t_float s_ai;
-    t_float ar;
-    t_float s_ar;
-    // zero data
-    t_float c0;
-    t_float s_c0;
-    t_float c1;
-    t_float s_c1;
-    t_float c2;
-    t_float s_c2;
-}butter_state;
-
-static void butter_bang_smooth (butter_state states[3], t_float input, t_float* output, t_float smooth){
-    for(int i = 0; i < 3; i++){
-        butter_state* s = states + i;
-        t_float d1t = s->s_ar * s->d1A + s->s_ai * s->d2A + input;
-        t_float d2t = s->s_ar * s->d2A - s->s_ai * s->d1A;
-        s->s_ar += smooth * (s->ar - s->s_ar);
-        s->s_ai += smooth * (s->ai - s->s_ai);
-        *output = s->s_c0 * input + s->s_c1 * s->d1A + s->s_c2 * s->d2A;
-        s->d1A = d1t;
-        s->d2A = d2t;
-        s->s_c0 += smooth * (s->c0 - s->s_c0);
-        s->s_c1 += smooth * (s->c1 - s->s_c1);
-        s->s_c2 += smooth * (s->c2 - s->s_c2);
-    }
-}
-
-static void butter_init(butter_state states[3]){
-    for(int i = 0; i < 3; i++){
-        butter_state* s = states + i;
-        s->d1A = s->d1B = s->d2A = s->d2B = 0.0;
-        s->ai = s->ar = s->c0 = s->c1 = s->c2 = 0.0;
-        s->s_ai = s->s_ar = s->s_c0 = s->s_c1 = s->s_c2 = 0.0;
-    }
-}
-
-static t_complex complex_div_f(t_float in1, t_complex in2) {
-    double real = (double)in1 / creal(in2);
-    double imag = (double)in1 / cimag(in2);
-    
-    return CMPLX(real,imag);
-}
-
-static t_complex complex_mult(t_complex in1, t_complex in2) {
-    double real = creal(in1) * creal(in2) - cimag(in1) * cimag(in2);
-    double imag = creal(in1) * cimag(in2) + creal(in2) * cimag(in1);
-    return CMPLX(real,imag);
-}
-
-static t_complex complex_div(t_complex in1, t_complex in2)
- {
-    double real = (creal(in1) * creal(in2) + cimag(in1) * cimag(in2)) / (creal(in2) * creal(in2) + cimag(in2) * cimag(in2));
-    double imag = (cimag(in1) * creal(in2) - creal(in1) * cimag(in2)) / (creal(in2) * creal(in2) + cimag(in2) * cimag(in2));
-    return CMPLX(real,imag);
- }
-
-static t_complex complex_subtract(t_complex in1, t_complex in2) {
-    double real = creal(in1) - creal(in2);
-    double imag = cimag(in1) - cimag(in2);
-    return CMPLX(real,imag);
-}
-
-
-static t_complex complex_with_angle(const t_float angle){
-    return CMPLX(cosf(angle), sinf(angle));
-}
-
-static t_float complex_norm2(const t_complex x){
-    return creal(x) * creal(x) + cimag(x) * cimag(x);
-}
-static t_float complex_norm(const t_complex x){
-    return sqrt(complex_norm2(x));
-}
-
-static void set_butter_hp(butter_state states[3], t_float freq){
-    //  This computes the poles for a highpass butterworth filter, transformed to the
-    // digital domain using a bilinear transform. Every biquad section is normalized at NY.
-    t_float epsilon = .0001; // stability guard
-    t_float min = 0.0 + epsilon;
-    t_float max = 0.5 - epsilon;
-    int sections = 3;
-    if(freq < min)
-        freq = min;
-    if(freq > max)
-        freq = max;
-    // prewarp cutoff frequency
-    t_float omega = 2.0 * tan(M_PI * freq);
-    t_complex pole = complex_with_angle( (2*sections + 1) * M_PI / (4*sections)); // first pole of lowpass filter with omega == 1
-    t_complex pole_inc = complex_with_angle(M_PI / (2*sections)); // phasor to get to next pole, see Porat p. 331
-    t_complex b = CMPLX(-1.0, 0.0); // normalize at NY
-    t_complex c = CMPLX(1.0, 0.0);  // all zeros will be at DC
-    for(int i = 0; i < sections; i++){
-        butter_state* s = states + i;
-        // setup the biquad with the computed pole and zero and unit gain at NY
-        pole = complex_mult(pole, pole_inc);            // comp next (lowpass) pole
-        t_complex a = complex_div_f(omega, pole);
-        s->ar = creal(a);
-        s->ai = cimag(a);
-        s->c0 = 1.0;
-        s->c1 = 2.0 * (creal(a) - creal(b));
-        s->c2 = (complex_norm2(a) - complex_norm2(b) - s->c1 * creal(a)) / cimag(a);
-        t_complex invComplexGain = complex_div(
-        complex_mult(complex_subtract(c, a), complex_subtract(c, conj(a))),
-        complex_mult(complex_subtract(c, b), complex_subtract(c, conj(b)))
-        );
+static t_int *blimp2_perform(t_int *w){
+    t_blimp* x        = (t_blimp*)(w[1]);
+    t_elliptic_blep* blep = &x->x_elliptic_blep;
+    t_int n            = (t_int)(w[2]);
+    t_float* freq_vec  = (t_float *)(w[3]);
+    t_float* out       = (t_float *)(w[4]);
+    while(n--){
+        t_float freq = *freq_vec++;
+        if(x->x_midi && freq < 256)
+            freq = pow(2, (freq - 69)/12) * 440;
         
-        t_float invGain = complex_norm(invComplexGain);
-        s->c0 *= invGain;
-        s->c1 *= invGain;
-        s->c2 *= invGain;
-    }
-}
-
-typedef struct bloscctl{
-    t_int c_index[VOICES];      // array of indices in sample table
-    t_float c_frac[VOICES];     // array of fractional indices
-    t_float c_vscale[VOICES];   // array of scale factors
-    t_int c_next_voice;         // next voice to steal (round robin)
-    uint32_t c_phase;                // phase of main oscillator
-    uint32_t c_phase2;               // phase of secondairy oscillator
-    t_float c_state;            // state of the square wave
-    t_float c_prev_amp;         // previous input of comparator
-    t_float c_phase_inc_scale;
-    t_float c_scale;
-    t_float c_scale_update;
-    butter_state c_butter[3]; // the series filter
-    t_symbol* c_waveshape;
-}t_bloscctl;
-
-typedef struct blosc{
-    t_object x_obj;
-    t_float x_f;
-    t_bloscctl x_ctl;
-    t_int midi;
-}t_blosc;
-
-/* phase converters */
-static inline uint32_t _float_to_phase(t_float f){return ((uint32_t)(f * 4294967296.0)) & ~(S-1);}
-
-/* flat table: better for linear interpolation */
-static inline t_float _play_voice_lint(t_float *table, t_int *index, t_float frac, t_float scale){
-    int i = *index;
-    /* perform linear interpolation */
-    t_float f = (((1.0 - frac) * table[i]) + (table[i+1] * frac)) * scale;
-    /* increment phase index if next 2 elements will still be inside table
-     if not there's no increment and the voice will keep playing the same sample */
-    i += (((i+S+1) >> LTABLE) ^ 1) << LOVERSAMPLE;
-    *index = i;
-    return(f);
-}
-
-/* get one sample from the bandlimited discontinuity wavetable playback syth */
-static inline t_float _get_bandlimited_discontinuity(t_bloscctl *ctl, t_float *table){
-    t_float sum = 0.0;
-    /* sum  all voices */
-    for(int i = 0; i < VOICES; i++)
-        sum += _play_voice_lint(table, ctl->c_index+i, ctl->c_frac[i], ctl->c_vscale[i]);
-    return(sum);
-}
-
-// advance phasor and update waveplayers on phase wrap
-static void _bang_phasor(t_bloscctl *ctl, t_float freq){
-    uint32_t phase = ctl->c_phase;
-    uint32_t phase_inc;
-    uint32_t oldphase;
-    int voice;
-    t_float scale = ctl->c_scale;
-    /* get increment */
-    t_float inc = freq * ctl->c_phase_inc_scale;
-    /* calculate new phase
-     the increment (and the phase) should be a multiple of S */
-    if(inc < 0.0) inc = -inc;
-    phase_inc = ((uint32_t)inc) & ~(S-1);
-    oldphase = phase;
-    phase += phase_inc;
-    /* check for phase wrap */
-    if(phase < oldphase){
-        uint32_t phase_inc_decimated = phase_inc >> LOVERSAMPLE;
-        uint32_t table_index;
-        uint32_t table_phase;
-        /* steal the oldest voice if we have a phase wrap */
-        voice = ctl->c_next_voice++;
-        ctl->c_next_voice &= VOICES-1;
-        /* determine the location of the discontinuity (in oversampled coordinates)
-         which is S * (new phase) / (increment) */
-        table_index = phase / phase_inc_decimated;
-        /* determine the fractional part (in oversampled coordinates)
-         for linear interpolation */
-        table_phase = phase - (table_index * phase_inc_decimated);
-        /* use it to initialize the new voice index and interpolation fraction */
-        ctl->c_index[voice] = table_index;
-        ctl->c_frac[voice] = (t_float)table_phase / (t_float)phase_inc_decimated;
-        ctl->c_vscale[voice] = scale;
-        scale = scale * ctl->c_scale_update;
-    }
-    /* save state */
-    ctl->c_phase = phase;
-    ctl->c_scale = scale;
-}
-
-/* the 2 oscillator version:
- the second osc can reset the first osc's phase (hence it determines the pitch)
- the first osc determines the waveform */
-/*static void _bang_hardsync_phasor(t_bloscctl *ctl, t_float freq, t_float freq2){
-    uint32_t phase = ctl->c_phase;
-    uint32_t phase2 = ctl->c_phase2;
-    uint32_t phase_inc;
-    uint32_t phase_inc2;
-    uint32_t oldphase;
-    uint32_t oldphase2;
-    int voice;
-    t_float scale = ctl->c_scale;
-    // get increment
-    t_float inc = freq * ctl->c_phase_inc_scale;
-    t_float inc2 = freq2 * ctl->c_phase_inc_scale;
-    // calculate new phases the increment (and the phase) should be a multiple of S
-    // save previous phases
-    oldphase = phase;
-    oldphase2 = phase2;
-    // update second osc
-    if(inc2 < 0.0) inc2 = -inc2;
-    phase_inc2 = ((uint32_t)inc2) & ~(S-1);
-    phase2 += phase_inc2;
-    // update first osc (freq should be >= freq of sync osc
-    if(inc < 0.0) inc = -inc;
-    phase_inc = ((uint32_t)inc) & ~(S-1);
-    if(phase_inc < phase_inc2) phase_inc = phase_inc2;
-    phase += phase_inc;
-    // check for sync discontinuity (osc 2)
-    if(phase2 < oldphase2){
-        // adjust phase depending on the location of the discontinuity in phase2:
-        // phase/phase_inc == phase2/phase_inc2
-        uint64_t pi = phase_inc >> LOVERSAMPLE;
-        uint64_t pi2 = phase_inc2 >> LOVERSAMPLE;
-        uint64_t lphase = ((uint64_t)phase2 * pi) / pi2;
-        phase = lphase & ~(S-1);
-    }
-    // check for phase discontinuity (osc 1)
-    if(phase < oldphase){
-        uint32_t phase_inc_decimated = phase_inc >> LOVERSAMPLE;
-        uint32_t table_index;
-        uint32_t table_phase;
-        t_float stepsize;
-        // steal the oldest voice if we have a phase wrap
-        voice = ctl->c_next_voice++;
-        ctl->c_next_voice &= VOICES-1;
-        // determine the location of the discontinuity (in oversampled coordinates)
-        // which is S * (new phase) / (increment)
-        table_index = phase / phase_inc_decimated;
-        // determine the fractional part (in oversampled coordinates)
-        // for linear interpolation
-        table_phase = phase - (table_index * phase_inc_decimated);
-        // determine the step size
-         as opposed to saw/impulse waveforms, the step is not always equal to one. it is:
-         oldphase - phase + phase_inc
-         but for the unit step this will overflow to zero, so we
-         reduce the bit depth to prevent overflow
-        stepsize = _phase_to_float(((oldphase-phase) >> LOVERSAMPLE)
-                                   + phase_inc_decimated) * (t_float)S;
-        // use it to initialize the new voice index and interpolation fraction
-        ctl->c_index[voice] = table_index;
-        ctl->c_frac[voice] = (t_float)table_phase / (t_float)phase_inc_decimated;
-        ctl->c_vscale[voice] = scale * stepsize;
-        scale = scale * ctl->c_scale_update;
-    }
-    // save state
-    ctl->c_phase = phase;
-    ctl->c_phase2 = phase2;
-    ctl->c_scale = scale;
-}*/
-
-/*static t_int *blosc_perform_hardsync_saw(t_int *w){
-    t_float *freq     = (t_float *)(w[3]);
-    t_float *freq2     = (t_float *)(w[4]);
-    t_float *out      = (t_float *)(w[5]);
-    t_bloscctl *ctl  = (t_bloscctl *)(w[1]);
-    int n             = (int)(w[2]);
-    set_butter_hp(ctl->c_butter, 0.85 * (*freq / sys_getsr()));
-    while(n--){
-        t_float frequency = *freq++;
-        t_float frequency2 = *freq2++;
-        // get the bandlimited discontinuity
-        t_float sample = _get_bandlimited_discontinuity(ctl, bls);
-        // add aliased sawtooth wave
-        sample += _phase_to_float(ctl->c_phase) - 0.5;
-        // highpass filter output to remove DC offset and low frequency aliasing
-        butter_bang_smooth(ctl->c_butter, sample, &sample, 0.05);
-        // send to output
-        *out++ = sample;
-        // advance phasor
-        _bang_hardsync_phasor(ctl, frequency2, frequency);
-    }
-    return(w+6);
-}*/
-
-static t_int *blosc_perform_imp(t_int *w){
-    t_blosc* x        = (t_blosc*)(w[1]);
-    t_bloscctl *ctl   = (t_bloscctl *)(w[2]);
-    int n             = (int)(w[3]);
-    t_float *freq     = (t_float *)(w[4]);
-    t_float *out      = (t_float *)(w[5]);
-    // set postfilter cutoff
-    set_butter_hp(ctl->c_butter, 0.85 * (*freq / sys_getsr()));
-    while(n--){
-        t_float frequency = *freq++;
-        if(x->midi)
-            frequency = pow(2, (frequency - 69)/12) * 440;
-        t_float sample = _get_bandlimited_discontinuity(ctl, bli);
-        // highpass filter output to remove DC offset and low frequency aliasing
-        butter_bang_smooth(ctl->c_butter, sample, &sample, 0.05);
-        *out++ = sample * 2;
-        _bang_phasor(ctl, frequency); // advance phasor
-    }
-    return(w+6);
-}
-
-static void blosc_midi(t_blosc *x, t_floatarg f){
-    x->midi = (int)(f != 0);
-}
-
-static void blosc_phase(t_blosc *x, t_float f){
-    x->x_ctl.c_phase = _float_to_phase(f);
-    x->x_ctl.c_phase2 = _float_to_phase(f);
-}
-
-/*static void blosc_phase1(t_blosc *x, t_float f){
-    x->x_ctl.c_phase = _float_to_phase(f);
-}*/
-
-static void blosc_phase2(t_blosc *x, t_float f){
-    x->x_ctl.c_phase2 = _float_to_phase(f);
-}
-
-
-/* CLASS DATA INIT (tables) */
-
-/* some vector ops */
-
-/* clear a buffer */
-static inline void _clear(t_float *array, int size){
-    memset(array, 0, sizeof(t_float)*size);
-}
-
-/* compute complex log */
-static inline void _clog(t_float *real, t_float *imag, int size){
-    for(int k = 0; k<size; k++){
-        t_float r = real[k];
-        t_float i = imag[k];
-        t_float radius = sqrt(r*r+i*i);
-        real[k] = log(radius);
-        imag[k] = atan2(i,r);
-    }
-}
-
-/* compute complex exp */
-static inline void _cexp(t_float *real, t_float *imag, int size){
-    for(int k = 0; k < size; k++){
-        t_float r = exp(real[k]);
-        t_float i = imag[k];
-        real[k] = r * cos(i);
-        imag[k] = r * sin(i);
-    }
-}
-
-/* compute fft */
-static inline void _fft(t_float *real, t_float *imag, int size){
-    t_float scale = 1.0 / sqrt((t_float)size);
-    for(int i = 0; i<size; i++){
-        real[i] *= scale;
-        imag[i] *= scale;
-        // if(isnan(real[i])) post("fftpanic %d", i);
-    }
-    mayer_fft(size, real, imag);
-}
-
-/* compute ifft */
-static inline void _ifft(t_float *real, t_float *imag, int size){
-    t_float scale = 1.0 / sqrt((t_float)size);
-    for(int i = 0; i<size; i++){
-        real[i] *= scale;
-        imag[i] *= scale;
-        // if(isnan(real[i])) post("ifftpanic %d", i);
-    }
-    mayer_ifft(size, real, imag);
-}
-
-/* convert an integer index to a phase: [0 -> pi, -pi -> 0] */
-static inline t_float _i2theta(int i, int size){
-    t_float p = 2.0 * M_PI * (t_float)i / (t_float)size;
-    if(p >= M_PI) p -= 2.0 * M_PI;
-    return p;
-}
-
-/* print matlab array */
-/*static void _printm(t_float *array, char *name, int size){
-    fprintf(stderr, "%s = [", name);
-    for(int i = 0; i<size; i++)
-        fprintf(stderr, "%f;", array[i]);
-    fprintf(stderr, "];\n");
-}*/
-
-/* store oversampled waveform as decimated chunks */
-/*static void _store_decimated(t_float *dst, t_float *src, t_float scale, int size){
-    for(int i = 0; i<size; i++){
-        int offset = (i % S) * L;
-        int index = i / S;
-        dst[offset+index] = scale * src[i];
-    }
-}*/
-
-/* store waveform as one chunk */
-static void _store(t_float *dst, t_float *src, t_float scale, int size){
-    for(int i = 0; i<size; i++)
-        dst[i] = scale * src[i];
-}
-
-/* create a minimum phase bandlimited impulse */
-static void build_tables(void){
-    /* table size = M>=N (time padding to reduce time aliasing) */
-    /* we work in the complex domain to eliminate the need to avoid
-     negative spectral components */
-    t_float real[M];
-    t_float imag[M];
-    t_float sum,scale;
-    int i;
-    /* create windowed sinc */
-    _clear(imag, M);
-    real[0] = 1.0;
-    for(i = 1; i<M; i++){
-        t_float tw = _i2theta(i,M);
-        t_float ts = tw * NBPERIODS * (t_float)(M) / (t_float)(N);
-        /* sinc */
-        real[i] = sin(ts)/ts;
-        /* blackman window */
-        real[i] *= 0.42 + 0.5 * (cos(tw)) + 0.08 * (cos(2.0*tw));
-        //real[i] *= 0.5f * (1.0f + WALPHA) + 0.5f * (1.0f - WALPHA) * (cos(tw));
-        /* check for nan */
-        //if(isnan(real[i])) post("sinc NaN panic %d", i);
-        //if(isinf(real[i])) post("sinc Inf panic %d", i);
-    }
-    /* compute cepstrum */
-    _fft(real, imag, M);
-    _clog(real, imag, M);
-    _ifft(real, imag, M);
-    /* kill anti-causal part (contribution of non minimum phase zeros) */
-    /* should we kill nyquist too ?? */
-    for(i=M/2+1; i<M; i++){
-        real[i] *= 0.0000;
-        imag[i] *= 0.0000;
-    }
-    /* compute inverse cepstrum */
-    _fft(real, imag, M);
-    _cexp(real, imag, M);
-    _ifft(real, imag, M);
-    /* from here on, discard the padded part [N->M-1]
-     and work with the first N samples */
+        *out++ = elliptic_blep_get(blep);
+        
+        t_float phase_increment = freq / x->x_sr; // Update frequency
+        x->x_phase += phase_increment;
     
-    /* normalize impulse (integral = 1) */
-    sum = 0.0;
-    for(i = 0; i<N; i++){sum += real[i];}
-    scale = 1.0 / sum;
-    for(i = 0; i<N; i++)
-        real[i] *= scale;
-    /* store bli table */
-    _store(bli, real, (t_float)S, N);
-    //_printm(bli, "h", N);
-    /* integrate impulse and invert to produce a step function
-     from 1->0 */
-    sum = 0.0;
-    for(i = 0; i < N; i++){
-        sum += real[i];
-        real[i] = (1.0 - sum);
+        elliptic_blep_step(blep);
+        
+        if(x->x_phase >= 1 || x->x_phase < 0) {
+            x->x_phase = x->x_phase < 0 ? x->x_phase+1 : x->x_phase-1;
+            t_float samples_in_past = x->x_phase / phase_increment;
+            elliptic_blep_add_in_past(blep, 1.0f, 0, samples_in_past);
+        }
+        else if (x->x_phase >= 0.5f && x->x_phase < 0.5f + phase_increment) {
+            t_float samples_in_past = (x->x_phase - 0.5f) / phase_increment;
+            elliptic_blep_add_in_past(blep, -1.0f, 0, samples_in_past);
+        }
     }
-    /* store decimated bls tables */
-    _store(bls, real, 1.0, N);
+    return(w+5);
 }
 
-static void blosc_dsp(t_blosc *x, t_signal **sp){
-    // set sampling rate scaling for phasors
-    x->x_ctl.c_phase_inc_scale = 4.0 * ((t_float)(1<<(LPHASOR-2))) / sys_getsr();
-    x->x_ctl.c_phase_inc_scale *= 2;
-    x->x_ctl.c_scale = 1.0;
-    x->x_ctl.c_scale_update = -1.0;
-    dsp_add(blosc_perform_imp, 5, x, &x->x_ctl, sp[0]->s_n, sp[0]->s_vec, sp[1]->s_vec);
+static void blimp2_midi(t_blimp *x, t_floatarg f){
+    x->x_midi = (int)(f != 0);
 }
 
-static void *blosc_new(t_symbol *s, int ac, t_atom *av){
-    t_blosc *x = (t_blosc *)pd_new(blosc_class);
-    x->midi = 0;
+static void blimp2_dsp(t_blimp *x, t_signal **sp){
+    x->x_sr = sp[0]->s_sr;
+    elliptic_blep_create(&x->x_elliptic_blep, 1, sp[0]->s_sr);
+    dsp_add(blimp2_perform, 4, x, sp[0]->s_n, sp[0]->s_vec, sp[1]->s_vec);
+}
 
-    butter_init(x->x_ctl.c_butter);
-    // init oscillators
-    for(int i = 0; i < VOICES; i++){
-      x->x_ctl.c_index[i] = N-2;
-      x->x_ctl.c_frac[i] = 0.0;
-    }
-    // init rest of state data
-    blosc_phase(x, 0);
-    blosc_phase2(x, 0);
-    x->x_ctl.c_state = 0.0;
-    x->x_ctl.c_prev_amp = 0.0;
-    x->x_ctl.c_next_voice = 0;
-    x->x_ctl.c_scale = 1.0;
-    x->x_ctl.c_scale_update = 1.0;
-    x->x_ctl.c_waveshape = s;
-    
+static void *blimp2_new(t_symbol *s, int ac, t_atom *av){
+    t_blimp *x = (t_blimp *)pd_new(blimp2_class);
+    x->x_phase = 0.0;
+    x->x_midi = 0;
+    x->x_direction = 1;
+    t_float init_freq = 0;
     if(ac && av->a_type == A_SYMBOL){
         if(atom_getsymbol(av) == gensym("-midi"))
-            x->midi = 1;
-        ac--, av++;
+            x->x_midi = 1;
     }
     if(ac && av->a_type == A_FLOAT){
-        x->x_f = av->a_w.w_float;
+        init_freq = av->a_w.w_float;
         ac--; av++;
     }
-    
-    outlet_new(&x->x_obj, gensym("signal"));
+    x->x_f = init_freq;
+    outlet_new(&x->x_obj, &s_signal);
     return(void *)x;
 }
 
 void setup_bl0x2eimp2_tilde(void){
-    build_tables();
-    blosc_class = class_new(gensym("bl.imp2~"), (t_newmethod)blosc_new,
-        0, sizeof(t_blosc), 0, A_GIMME, A_NULL);
-    CLASS_MAINSIGNALIN(blosc_class, t_blosc, x_f);
-    class_addmethod(blosc_class, (t_method)blosc_midi, gensym("midi"), A_DEFFLOAT, 0);
-    class_addmethod(blosc_class, (t_method)blosc_dsp, gensym("dsp"), A_NULL);
+    blimp2_class = class_new(gensym("bl.imp2~"), (t_newmethod)blimp2_new,
+        0, sizeof(t_blimp), 0, A_GIMME, A_NULL);
+    CLASS_MAINSIGNALIN(blimp2_class, t_blimp, x_f);
+    class_addmethod(blimp2_class, (t_method)blimp2_midi, gensym("midi"), A_DEFFLOAT, 0);
+    class_addmethod(blimp2_class, (t_method)blimp2_dsp, gensym("dsp"), A_NULL);
 }
+

--- a/Source/Audio/bl.imp~.c
+++ b/Source/Audio/bl.imp~.c
@@ -1,455 +1,77 @@
 // tim schoen
 
 #include <m_pd.h>
+#include <blep.h>
 
-#define _USE_MATH_DEFINES
-
-#include <math.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <complex.h>
-
-#if _MSC_VER
-#define t_complex _Dcomplex
-#ifndef CMPLX
-#define CMPLX(re,im) (t_complex){re,im}
-#endif
-#else
-#define t_complex complex double
-#ifdef __MINGW32__
-// mingw apparently lacks this macro in complex.h
-#ifndef CMPLX
-#define CMPLX(x, y) __builtin_complex ((double) (x), (double) (y))
-#endif
-#endif
-#endif
-
-// TODO: some of these aren't used
-#define LPHASOR      (8*sizeof(uint32_t)) // the phasor logsize
-#define VOICES       8 // the number of waveform voices
-#define LLENGTH      6 // the loglength of a fractional delayed basic waveform
-#define LOVERSAMPLE  6 // the log of the oversampling factor (nb of fract delayed waveforms)
-#define LPAD         1 // the log of the time padding factor (to reduce time aliasing)
-#define LTABLE       (LLENGTH+LOVERSAMPLE)
-#define N            (1<<LTABLE)
-#define M            (1<<(LTABLE+LPAD))
-#define S            (1<<LOVERSAMPLE)
-#define L            (1<<LLENGTH)
-#define CUTOFF       0.8 // fraction of nyquist for impulse cutoff
-#define NBPERIODS    ((t_float)(L) * CUTOFF / 2.0)
-
-// sample buffers
-static t_float bli[N]; // band limited impulse
-static t_float bls[N]; // band limited step
+typedef struct blimp{
+    t_object    x_obj;
+    t_float     x_f;
+    t_elliptic_blep x_elliptic_blep;
+    t_float     x_phase;
+    t_float     x_sr;
+    t_int       x_midi;
+}t_blimp;
 
 t_class *blimp_class;
 
-typedef struct _butter_state{
-    // state data
-    t_float d1A;
-    t_float d2A;
-    t_float d1B;
-    t_float d2B;
-    // pole data
-    t_float ai;
-    t_float s_ai;
-    t_float ar;
-    t_float s_ar;
-    // zero data
-    t_float c0;
-    t_float s_c0;
-    t_float c1;
-    t_float s_c1;
-    t_float c2;
-    t_float s_c2;
-}butter_state;
-
-void butter_bang_smooth (butter_state states[3], t_float input, t_float* output, t_float smooth){
-    for(int i = 0; i < 3; i++){
-        butter_state* s = states + i;
-        t_float d1t = s->s_ar * s->d1A + s->s_ai * s->d2A + input;
-        t_float d2t = s->s_ar * s->d2A - s->s_ai * s->d1A;
-        s->s_ar += smooth * (s->ar - s->s_ar);
-        s->s_ai += smooth * (s->ai - s->s_ai);
-        *output = s->s_c0 * input + s->s_c1 * s->d1A + s->s_c2 * s->d2A;
-        s->d1A = d1t;
-        s->d2A = d2t;
-        s->s_c0 += smooth * (s->c0 - s->s_c0);
-        s->s_c1 += smooth * (s->c1 - s->s_c1);
-        s->s_c2 += smooth * (s->c2 - s->s_c2);
-    }
-}
-
-void butter_init(butter_state states[3]){
-    for(int i = 0; i < 3; i++){
-        butter_state* s = states + i;
-        s->d1A = s->d1B = s->d2A = s->d2B = 0.0;
-        s->ai = s->ar = s->c0 = s->c1 = s->c2 = 0.0;
-        s->s_ai = s->s_ar = s->s_c0 = s->s_c1 = s->s_c2 = 0.0;
-    }
-}
-
-t_complex complex_div_f(t_float in1, t_complex in2) {
-    double real = (double)in1 / creal(in2);
-    double imag = (double)in1 / cimag(in2);
-    
-    return CMPLX(real,imag);
-}
-
-t_complex complex_mult(t_complex in1, t_complex in2) {
-    double real = creal(in1) * creal(in2) - cimag(in1) * cimag(in2);
-    double imag = creal(in1) * cimag(in2) + creal(in2) * cimag(in1);
-    return CMPLX(real,imag);
-}
-
-t_complex complex_div(t_complex in1, t_complex in2)
- {
-    double real = (creal(in1) * creal(in2) + cimag(in1) * cimag(in2)) / (creal(in2) * creal(in2) + cimag(in2) * cimag(in2));
-    double imag = (cimag(in1) * creal(in2) - creal(in1) * cimag(in2)) / (creal(in2) * creal(in2) + cimag(in2) * cimag(in2));
-    return CMPLX(real,imag);
- }
-
-t_complex complex_add(t_complex in1, t_complex in2) {
-    double real = creal(in1) + creal(in2);
-    double imag = cimag(in1) + cimag(in2);
-    return CMPLX(real,imag);
-}
-
-t_complex complex_subtract(t_complex in1, t_complex in2) {
-    double real = creal(in1) - creal(in2);
-    double imag = cimag(in1) - cimag(in2);
-    return CMPLX(real,imag);
-}
-
-
-t_complex complex_with_angle(const t_float angle){
-    return CMPLX(cosf(angle), sinf(angle));
-}
-
-t_float complex_norm2(const t_complex x){
-    return creal(x) * creal(x) + cimag(x) * cimag(x);
-}
-t_float complex_norm(const t_complex x){
-    return sqrt(complex_norm2(x));
-}
-
-void set_butter_hp(butter_state states[3], t_float freq){
-    //  This computes the poles for a highpass butterworth filter, transformed to the
-    // digital domain using a bilinear transform. Every biquad section is normalized at NY.
-    t_float epsilon = .0001; // stability guard
-    t_float min = 0.0 + epsilon;
-    t_float max = 0.5 - epsilon;
-    int sections = 3;
-    if(freq < min)
-        freq = min;
-    if(freq > max)
-        freq = max;
-    // prewarp cutoff frequency
-    t_float omega = 2.0 * tan(M_PI * freq);
-    t_complex pole = complex_with_angle( (2*sections + 1) * M_PI / (4*sections)); // first pole of lowpass filter with omega == 1
-    t_complex pole_inc = complex_with_angle(M_PI / (2*sections)); // phasor to get to next pole, see Porat p. 331
-    t_complex b = CMPLX(-1.0, 0.0); // normalize at NY
-    t_complex c = CMPLX(1.0, 0.0);  // all zeros will be at DC
-    for(int i = 0; i < sections; i++){
-        butter_state* s = states + i;
-        // setup the biquad with the computed pole and zero and unit gain at NY
-        pole = complex_mult(pole, pole_inc);            // comp next (lowpass) pole
-        t_complex a = complex_div_f(omega, pole);
-        s->ar = creal(a);
-        s->ai = cimag(a);
-        s->c0 = 1.0;
-        s->c1 = 2.0 * (creal(a) - creal(b));
-        s->c2 = (complex_norm2(a) - complex_norm2(b) - s->c1 * creal(a)) / cimag(a);
-        t_complex invComplexGain = complex_div(
-        complex_mult(complex_subtract(c, a), complex_subtract(c, conj(a))),
-        complex_mult(complex_subtract(c, b), complex_subtract(c, conj(b)))
-        );
-        
-        t_float invGain = complex_norm(invComplexGain);
-        s->c0 *= invGain;
-        s->c1 *= invGain;
-        s->c2 *= invGain;
-    }
-}
-
-typedef struct blimpctl{
-    t_int c_index[VOICES];      // array of indices in sample table
-    t_float c_frac[VOICES];     // array of fractional indices
-    t_float c_vscale[VOICES];   // array of scale factors
-    t_int c_next_voice;         // next voice to steal (round robin)
-    uint32_t c_phase;           // phase of main oscillator
-    uint32_t c_phase2;          // phase of secondairy oscillator
-    t_float c_state;            // state of the square wave
-    t_float c_prev_amp;         // previous input of comparator
-    t_float c_phase_inc_scale;
-    t_float c_scale;
-    t_float c_scale_update;
-    butter_state c_butter[3];   // the series filter
-    t_symbol* c_waveshape;
-}t_blimpctl;
-
-typedef struct blimp{
-    t_object x_obj;
-    t_float x_f;
-    t_blimpctl x_ctl;
-    t_int midi;
-}t_blimp;
-
-static inline uint32_t _float_to_phase(t_float f){return ((uint32_t)(f * 4294967296.0)) & ~(S-1);}
-
-// flat table: better for linear interpolation
-static inline t_float _play_voice_lint(t_float *table, t_int *index, t_float frac, t_float scale){
-    int i = *index;
-    // perform linear interpolation
-    t_float f = (((1.0 - frac) * table[i]) + (table[i+1] * frac)) * scale;
-    // increment phase index if next 2 elements will still be inside table if
-    // not there's no increment and the voice will keep playing the same sample
-    i += (((i+S+1) >> LTABLE) ^ 1) << LOVERSAMPLE;
-    *index = i;
-    return(f);
-}
-
-// get one sample from the bandlimited discontinuity wavetable playback syth
-static inline t_float _get_bandlimited_discontinuity(t_blimpctl *ctl, t_float *table){
-    t_float sum = 0.0;
-    for(int i = 0; i < VOICES; i++) // sum  all voices
-        sum += _play_voice_lint(table, ctl->c_index+i, ctl->c_frac[i], ctl->c_vscale[i]);
-    return(sum);
-}
-
-// advance phasor and update waveplayers on phase wrap
-static void _bang_phasor(t_blimpctl *ctl, t_float freq){
-    uint32_t phase = ctl->c_phase;
-    uint32_t phase_inc;
-    uint32_t oldphase;
-    int voice;
-    t_float scale = ctl->c_scale;
-    // get increment
-    t_float inc = freq * ctl->c_phase_inc_scale;
-    // calculate new phase the increment (and the phase) should be a multiple of S
-    if(inc < 0.0) inc = -inc;
-    phase_inc = ((uint32_t)inc) & ~(S-1);
-    oldphase = phase;
-    phase += phase_inc;
-    // check for phase wrap
-    if(phase < oldphase){
-        uint32_t phase_inc_decimated = phase_inc >> LOVERSAMPLE;
-        uint32_t table_index;
-        uint32_t table_phase;
-        // steal the oldest voice if we have a phase wrap
-        voice = ctl->c_next_voice++;
-        ctl->c_next_voice &= VOICES-1;
-        // determine the location of the discontinuity (in oversampled coordinates)
-        // which is S * (new phase) / (increment)
-        table_index = phase / phase_inc_decimated;
-        // determine the fractional part (in oversampled coordinates)
-        // for linear interpolation
-        table_phase = phase - (table_index * phase_inc_decimated);
-        // use it to initialize the new voice index and interpolation fraction
-        ctl->c_index[voice] = table_index;
-        ctl->c_frac[voice] = (t_float)table_phase / (t_float)phase_inc_decimated;
-        ctl->c_vscale[voice] = scale;
-        scale = scale * ctl->c_scale_update;
-    }
-    // save state
-    ctl->c_phase = phase;
-    ctl->c_scale = scale;
-}
-
-static t_int *blimp_perform_imp(t_int *w){
+static t_int *blimp_perform(t_int *w){
     t_blimp* x        = (t_blimp*)(w[1]);
-    t_blimpctl *ctl   = (t_blimpctl *)(w[2]);
-    int n             = (int)(w[3]);
-    t_float *freq     = (t_float *)(w[4]);
-    t_float *out      = (t_float *)(w[5]);
-    // set postfilter cutoff
-    set_butter_hp(ctl->c_butter, 0.85 * (*freq / sys_getsr()));
+    t_elliptic_blep* blep = &x->x_elliptic_blep;
+    t_int n            = (t_int)(w[2]);
+    t_float* freq_vec  = (t_float *)(w[3]);
+    t_float* out       = (t_float *)(w[4]);
     while(n--){
-        t_float frequency = *freq++;
-        if(x->midi)
-            frequency = pow(2, (frequency - 69)/12) * 440;
-        t_float sample = _get_bandlimited_discontinuity(ctl, bli);
-        // highpass filter output to remove DC offset and low frequency aliasing
-        butter_bang_smooth(ctl->c_butter, sample, &sample, 0.05);
-        *out++ = sample * 2;
-        _bang_phasor(ctl, frequency); // advance phasor
+        t_float freq = *freq_vec++;
+        if(x->x_midi && freq < 256)
+            freq = pow(2, (freq - 69)/12) * 440;
+        
+        *out++ = elliptic_blep_get(blep);
+        
+        t_float phase_increment = freq / x->x_sr; // Update frequency
+        x->x_phase += phase_increment;
+    
+        elliptic_blep_step(blep);
+        
+        if(x->x_phase >= 1 || x->x_phase < 0) {
+            x->x_phase = x->x_phase < 0 ? x->x_phase+1 : x->x_phase-1;
+            t_float samples_in_past = x->x_phase / phase_increment;
+            elliptic_blep_add_in_past(blep, 1.0f, 0, samples_in_past);
+        }
     }
-    return(w+6);
+    return(w+5);
 }
 
 static void blimp_midi(t_blimp *x, t_floatarg f){
-    x->midi = (int)(f != 0);
-}
-
-static void blimp_phase(t_blimp *x, t_float f){
-    x->x_ctl.c_phase = _float_to_phase(f);
-    x->x_ctl.c_phase2 = _float_to_phase(f);
-}
-
-static void blimp_phase2(t_blimp *x, t_float f){
-    x->x_ctl.c_phase2 = _float_to_phase(f);
-}
-
-// CLASS DATA INIT (tables)
-
-// some vector ops
-
-// clear a buffer
-static inline void _clear(t_float *array, int size){
-    memset(array, 0, sizeof(t_float)*size);
-}
-
-// compute complex log
-static inline void _clog(t_float *real, t_float *imag, int size){
-    for(int k = 0; k<size; k++){
-        t_float r = real[k];
-        t_float i = imag[k];
-        t_float radius = sqrt(r*r+i*i);
-        real[k] = log(radius);
-        imag[k] = atan2(i,r);
-    }
-}
-
-// compute complex exp
-static inline void _cexp(t_float *real, t_float *imag, int size){
-    for(int k = 0; k < size; k++){
-        t_float r = exp(real[k]);
-        t_float i = imag[k];
-        real[k] = r * cos(i);
-        imag[k] = r * sin(i);
-    }
-}
-
-// compute fft
-static inline void _fft(t_float *real, t_float *imag, int size){
-    t_float scale = 1.0 / sqrt((t_float)size);
-    for(int i = 0; i<size; i++){
-        real[i] *= scale;
-        imag[i] *= scale;
-    }
-    mayer_fft(size, real, imag);
-}
-
-// compute ifft
-static inline void _ifft(t_float *real, t_float *imag, int size){
-    t_float scale = 1.0 / sqrt((t_float)size);
-    for(int i = 0; i<size; i++){
-        real[i] *= scale;
-        imag[i] *= scale;
-    }
-    mayer_ifft(size, real, imag);
-}
-
-// convert an integer index to a phase: [0 -> pi, -pi -> 0]
-static inline t_float _i2theta(int i, int size){
-    t_float p = 2.0 * M_PI * (t_float)i / (t_float)size;
-    if(p >= M_PI) p -= 2.0 * M_PI;
-    return p;
-}
-
-// store waveform as one chunk
-static void _store(t_float *dst, t_float *src, t_float scale, int size){
-    for(int i = 0; i<size; i++)
-        dst[i] = scale * src[i];
-}
-
-// create a minimum phase bandlimited impulse
-static void build_tables(void){
-    // table size = M>=N (time padding to reduce time aliasing)
-    // we work in the complex domain to eliminate the need to avoid
-    // negative spectral components
-    t_float real[M];
-    t_float imag[M];
-    t_float sum,scale;
-    int i;
-    // create windowed sinc
-    _clear(imag, M);
-    real[0] = 1.0;
-    for(i = 1; i<M; i++){
-        t_float tw = _i2theta(i,M);
-        t_float ts = tw * NBPERIODS * (t_float)(M) / (t_float)(N);
-        // sinc
-        real[i] = sin(ts)/ts;
-        // blackman window
-        real[i] *= 0.42 + 0.5 * (cos(tw)) + 0.08 * (cos(2.0*tw));
-    }
-    // compute cepstrum
-    _fft(real, imag, M);
-    _clog(real, imag, M);
-    _ifft(real, imag, M);
-    // kill anti-causal part (contribution of non minimum phase zeros)
-    // should we kill nyquist too ??
-    for(i = M/2 + 1; i < M; i++){
-        real[i] *= 0.0000;
-        imag[i] *= 0.0000;
-    }
-    // compute inverse cepstrum
-    _fft(real, imag, M);
-    _cexp(real, imag, M);
-    _ifft(real, imag, M);
-    // from here on, discard the padded part [N->M-1]
-    // and work with the first N samples
-    
-    // normalize impulse (integral = 1)
-    sum = 0.0;
-    for(i = 0; i < N; i++)
-        sum += real[i];
-    scale = 1.0 / sum;
-    for(i = 0; i < N; i++)
-        real[i] *= scale;
-    // store bli table
-    _store(bli, real, (t_float)S, N);
-    // _printm(bli, "h", N);
-    // integrate impulse and invert to produce a step function from 1->0 
-    sum = 0.0;
-    for(i = 0; i < N; i++){
-        sum += real[i];
-        real[i] = (1.0 - sum);
-    }
-    // store decimated bls tables
-    _store(bls, real, 1.0, N);
+    x->x_midi = (int)(f != 0);
 }
 
 static void blimp_dsp(t_blimp *x, t_signal **sp){
-    x->x_ctl.c_phase_inc_scale = 4.0 * ((t_float)(1<<(LPHASOR-2))) / sys_getsr();
-    dsp_add(blimp_perform_imp, 5, x, &x->x_ctl, sp[0]->s_n, sp[0]->s_vec, sp[1]->s_vec);
+    x->x_sr = sp[0]->s_sr;
+    
+    elliptic_blep_create(&x->x_elliptic_blep, 1, sp[0]->s_sr);
+    
+    dsp_add(blimp_perform, 4, x, sp[0]->s_n, sp[0]->s_vec, sp[1]->s_vec);
 }
 
 static void *blimp_new(t_symbol *s, int ac, t_atom *av){
     t_blimp *x = (t_blimp *)pd_new(blimp_class);
-    x->midi = 0;
-    butter_init(x->x_ctl.c_butter);
-    // init oscillators
-    for(int i = 0; i < VOICES; i++){
-      x->x_ctl.c_index[i] = N-2;
-      x->x_ctl.c_frac[i] = 0.0;
-    }
-    // init rest of state data
-    blimp_phase(x, 0);
-    blimp_phase2(x, 0);
-    x->x_ctl.c_state = 0.0;
-    x->x_ctl.c_prev_amp = 0.0;
-    x->x_ctl.c_next_voice = 0;
-    x->x_ctl.c_scale = 1.0;
-    x->x_ctl.c_scale_update = 1.0;
-    x->x_ctl.c_waveshape = s;
-    
+    x->x_phase = 0.0;
+    x->x_midi = 0;
+    t_float init_freq = 0;
     if(ac && av->a_type == A_SYMBOL){
         if(atom_getsymbol(av) == gensym("-midi"))
-            x->midi = 1;
-        ac--, av++;
+            x->x_midi = 1;
     }
     if(ac && av->a_type == A_FLOAT){
-        x->x_f = av->a_w.w_float;
+        init_freq = av->a_w.w_float;
         ac--; av++;
     }
-    outlet_new(&x->x_obj, gensym("signal"));
+    x->x_f = init_freq;
+    outlet_new(&x->x_obj, &s_signal);
     return(void *)x;
 }
 
 void setup_bl0x2eimp_tilde(void){
-    build_tables();
     blimp_class = class_new(gensym("bl.imp~"), (t_newmethod)blimp_new,
         0, sizeof(t_blimp), 0, A_GIMME, A_NULL);
     CLASS_MAINSIGNALIN(blimp_class, t_blimp, x_f);

--- a/Source/Audio/bl.saw2~.c
+++ b/Source/Audio/bl.saw2~.c
@@ -1,76 +1,36 @@
-// License: BSD 2 Clause
-// Created by Timothy Schoen and Porres, based on LabSound polyBLEP oscillators
-
-// Adapted from "Phaseshaping Oscillator Algorithms for Musical Sound
-// Synthesis" by Jari Kleimola, Victor Lazzarini, Joseph Timoney, and Vesa
-// Valimaki. http://www.acoustics.hut.fi/publications/papers/smc2010-phaseshaping/
+// Created by Timothy Schoen and Porres
+// Based on Elliptic BLEP by signalsmith-audio: https://github.com/Signalsmith-Audio/elliptic-blep
 
 #include <m_pd.h>
-#include <math.h>
-#include <stdint.h>
+#include <blep.h>
 
-#define PI     3.1415926535897931
-#define TWO_PI 6.2831853071795862
-
-typedef struct _polyblep{
-    t_float pulse_width;    // Pulse width for square, morph-to-saw for triangle
-    t_float phase;          // The current phase of the oscillator.
-    t_float freq_in_seconds_per_sample;
-    t_int midi;
-    t_int soft;
-    t_float sr;
-    t_float last_phase_offset;
-}t_polyblep;
-
-typedef struct blsaw2{
+typedef struct blsaw{
     t_object    x_obj;
     t_float     x_f;
-    t_polyblep  x_polyblep;
+    t_elliptic_blep x_elliptic_blep;
     t_inlet*    x_inlet_sync;
     t_inlet*    x_inlet_phase;
-}t_blsaw2;
+    t_float     x_phase;
+    t_float     x_sr;
+    t_float     x_last_phase_offset;
+    t_int       x_midi;
+    t_int       x_soft;
+}t_blsaw;
 
-t_class *bl_saw2;
+t_class *blsaw2_class;
 
-static void blsaw2_midi(t_blsaw2 *x, t_floatarg f){
-    x->x_polyblep.midi = (int)(f != 0);
+static void blsaw2_midi(t_blsaw *x, t_floatarg f){
+    x->x_midi = (int)(f != 0);
 }
 
-static void blsaw2_soft(t_blsaw2 *x, t_floatarg f){
-    x->x_polyblep.soft = (int)(f != 0);
+static void blsaw2_soft(t_blsaw *x, t_floatarg f){
+    x->x_soft = (int)(f != 0);
 }
 
-static t_float phasewrap(t_float phase){
-    while(phase < 0.0)
-        phase += 1.0;
-    while(phase >= 1.0)
-        phase -= 1.0;
-    return(phase);
-}
-
-static t_float square(t_float x){
-    return(x * x);
-}
-
-static t_float blep(t_float phase, t_float dt){
-    if(phase < dt)
-        return(-square(phase / dt - 1));
-    else if(phase > 1 - dt)
-        return(square((phase - 1) / dt + 1));
-    else
-        return(0.0);
-}
-
-static t_float saw(const t_polyblep* x){
-    t_float _t = x->phase + 0.5;
-    _t = phasewrap(_t);
-    t_float y = 1 - 2 * _t;
-    y += blep(_t, x->freq_in_seconds_per_sample);
-    return(-y);
-}
 
 static t_int* blsaw2_perform(t_int *w) {
-    t_polyblep* x      = (t_polyblep*)(w[1]);
+    t_blsaw* x =          (t_blsaw*)(w[1]);
+    t_elliptic_blep* blep = &x->x_elliptic_blep;
     t_int n            = (t_int)(w[2]);
     t_float* freq_vec  = (t_float *)(w[3]);
     t_float* sync_vec  = (t_float *)(w[4]);
@@ -80,68 +40,73 @@ static t_int* blsaw2_perform(t_int *w) {
         t_float freq = *freq_vec++;
         t_float sync = *sync_vec++;
         t_float phase_offset = *phase_vec++;
-        if(x->midi)
+        if(x->x_midi && freq < 256)
             freq = pow(2, (freq - 69)/12) * 440;
-        x->freq_in_seconds_per_sample = freq / x->sr; // Update frequency
-        if(x->soft)
-            x->freq_in_seconds_per_sample *= x->soft;
+        
         if(sync > 0 && sync <= 1){ // Phase sync
-            if(x->soft)
-                x->soft = x->soft == 1 ? -1 : 1;
+            if(x->x_soft)
+                x->x_soft = x->x_soft == 1 ? -1 : 1;
             else{
-                x->phase = sync;
-                x->phase = phasewrap(x->phase);
+                x->x_phase = phasewrap(sync);
             }
         }
-        else{ // Phase modulation
-            double phase_dev = phase_offset - x->last_phase_offset;
-            if(phase_dev >= 1 || phase_dev <= -1)
-                phase_dev = fmod(phase_dev, 1);
-            x->phase = phasewrap(x->phase + phase_dev);
+        else { // Phase modulation
+            double phase_dev = phase_offset - x->x_last_phase_offset;
+            x->x_phase = phasewrap(x->x_phase + phase_dev);
         }
-        t_float y = saw(x);
-        x->phase += x->freq_in_seconds_per_sample;
-        x->phase = phasewrap(x->phase);
-        x->last_phase_offset = phase_offset;
-        *out++ = y;  // Send to output
+        
+        *out++ = (2.0f * x->x_phase - 1.0f) + elliptic_blep_get(blep);
+        
+        t_float phase_increment = freq / x->x_sr; // Update frequency
+        x->x_phase += phase_increment;
+        if(x->x_soft)
+            phase_increment *= x->x_soft;
+        
+        elliptic_blep_step(blep);
+        
+        if(x->x_phase >= 1 || x->x_phase < 0) {
+            x->x_phase = x->x_phase < 0 ? x->x_phase+1 : x->x_phase-1;
+            t_float samples_in_past = x->x_phase / phase_increment;
+            elliptic_blep_add_in_past(blep, -2.0f, 1, samples_in_past);
+        }
+        
+        x->x_last_phase_offset = phase_offset;
     }
     return(w+7);
 }
 
-static void blsaw2_dsp(t_blsaw2 *x, t_signal **sp){
-    x->x_polyblep.sr = sp[0]->s_sr;
-    dsp_add(blsaw2_perform, 6, &x->x_polyblep, sp[0]->s_n, sp[0]->s_vec,
+static void blsaw2_dsp(t_blsaw *x, t_signal **sp){
+    x->x_sr = sp[0]->s_sr;
+    
+    elliptic_blep_create(&x->x_elliptic_blep, 0, sp[0]->s_sr);
+    
+    dsp_add(blsaw2_perform, 6, x, sp[0]->s_n, sp[0]->s_vec,
             sp[1]->s_vec, sp[2]->s_vec, sp[3]->s_vec);
  }
 
-static void blsaw2_free(t_blsaw2 *x){
+static void blsaw2_free(t_blsaw *x){
     inlet_free(x->x_inlet_sync);
     inlet_free(x->x_inlet_phase);
 }
 
 static void* blsaw2_new(t_symbol *s, int ac, t_atom *av){
     s = NULL;
-    t_blsaw2* x = (t_blsaw2 *)pd_new(bl_saw2);
-    x->x_polyblep.pulse_width = 0;
-    x->x_polyblep.freq_in_seconds_per_sample = 0;
-    x->x_polyblep.phase = 0.0;
-    x->x_polyblep.midi = 0;
-    x->x_polyblep.soft = 0;
+    t_blsaw* x = (t_blsaw *)pd_new(blsaw2_class);
+    x->x_phase = 0.0;
+    x->x_soft = 0;
+    x->x_midi = 0;
+    x->x_last_phase_offset = 0;
     t_float init_freq = 0, init_phase = 0;
     while(ac && av->a_type == A_SYMBOL){
         if(atom_getsymbol(av) == gensym("-midi"))
-            x->x_polyblep.midi = 1;
+            x->x_midi = 1;
         else if(atom_getsymbol(av) == gensym("-soft"))
-            x->x_polyblep.soft = 1;
+            x->x_soft = 1;
         ac--, av++;
     }
     if(ac && av->a_type == A_FLOAT){
         init_freq = av->a_w.w_float;
         ac--; av++;
-        if(ac && av->a_type == A_FLOAT){
-            x->x_polyblep.pulse_width = av->a_w.w_float;
-            ac--; av++;
-        }
         if(ac && av->a_type == A_FLOAT){
             init_phase = av->a_w.w_float;
             ac--; av++;
@@ -157,10 +122,10 @@ static void* blsaw2_new(t_symbol *s, int ac, t_atom *av){
 }
 
 void setup_bl0x2esaw2_tilde(void){
-    bl_saw2 = class_new(gensym("bl.saw2~"), (t_newmethod)blsaw2_new,
-        (t_method)blsaw2_free, sizeof(t_blsaw2), 0, A_GIMME, A_NULL);
-    CLASS_MAINSIGNALIN(bl_saw2, t_blsaw2, x_f);
-    class_addmethod(bl_saw2, (t_method)blsaw2_midi, gensym("midi"), A_DEFFLOAT, 0);
-    class_addmethod(bl_saw2, (t_method)blsaw2_soft, gensym("soft"), A_DEFFLOAT, 0);
-    class_addmethod(bl_saw2, (t_method)blsaw2_dsp, gensym("dsp"), A_NULL);
+    blsaw2_class = class_new(gensym("bl.saw2~"), (t_newmethod)blsaw2_new,
+        (t_method)blsaw2_free, sizeof(t_blsaw), 0, A_GIMME, A_NULL);
+    CLASS_MAINSIGNALIN(blsaw2_class, t_blsaw, x_f);
+    class_addmethod(blsaw2_class, (t_method)blsaw2_midi, gensym("midi"), A_DEFFLOAT, 0);
+    class_addmethod(blsaw2_class, (t_method)blsaw2_soft, gensym("soft"), A_DEFFLOAT, 0);
+    class_addmethod(blsaw2_class, (t_method)blsaw2_dsp, gensym("dsp"), A_NULL);
 }

--- a/Source/Audio/bl.square~.c
+++ b/Source/Audio/bl.square~.c
@@ -1,78 +1,37 @@
-// License: BSD 2 Clause
-// Created by Timothy Schoen and Porres, based on LabSound polyBLEP oscillators
-
-// Adapted from "Phaseshaping Oscillator Algorithms for Musical Sound
-// Synthesis" by Jari Kleimola, Victor Lazzarini, Joseph Timoney, and Vesa
-// Valimaki. http://www.acoustics.hut.fi/publications/papers/smc2010-phaseshaping/
+// Created by Timothy Schoen and Porres
+// Based on Elliptic BLEP by signalsmith-audio: https://github.com/Signalsmith-Audio/elliptic-blep
 
 #include <m_pd.h>
-#include <math.h>
-#include <stdint.h>
-
-#define PI     3.1415926535897931
-#define TWO_PI 6.2831853071795862
-
-typedef struct _polyblep{
-    t_float pulse_width;    // Pulse width for square, morph-to-saw for triangle
-    t_float phase;          // The current phase of the oscillator.
-    t_float freq_in_seconds_per_sample;
-    t_int midi;
-    t_float sr;
-    t_int soft;
-    t_float last_phase_offset;
-}t_polyblep;
+#include <blep.h>
 
 typedef struct blsquare{
     t_object x_obj;
     t_float x_f;
-    t_polyblep x_polyblep;
+    t_elliptic_blep x_elliptic_blep;
     t_inlet* x_inlet_sync;
     t_inlet* x_inlet_phase;
     t_inlet* x_inlet_width;
+    t_float     x_phase;
+    t_float     x_sr;
+    t_float     x_last_phase_offset;
+    t_float     x_pulse_width;
+    t_int       x_midi;
+    t_int       x_soft;
 }t_blsquare;
 
-t_class *bl_square;
+t_class *blsquare_class;
 
 static void blsquare_midi(t_blsquare *x, t_floatarg f){
-    x->x_polyblep.midi = (int)(f != 0);
+    x->x_midi = (int)(f != 0);
 }
 
 static void blsquare_soft(t_blsquare *x, t_floatarg f){
-    x->x_polyblep.soft = (int)(f != 0);
-}
-
-static t_float phasewrap(t_float phase){
-    while (phase < 0.0)
-        phase += 1.0;
-    while(phase >= 1.0)
-        phase -= 1.0;
-    return(phase);
-}
-
-static t_float square(t_float x){
-    return(x * x);
-}
-
-static t_float blep(t_float phase, t_float dt){
-    if(phase < dt)
-        return(-square(phase / dt - 1));
-    else if(phase > 1 - dt)
-        return(square((phase - 1) / dt + 1));
-    else
-        return(0.0);
-}
-
-static t_float sqr(const t_polyblep* x){
-    t_float pulse_width = fmax(0.0001, fmin(0.9999, x->pulse_width));
-    t_float t2 = x->phase + 0.5;
-    t2 = phasewrap(t2);
-    t_float y = x->phase < pulse_width ? 1 : -1;
-    y += blep(x->phase, x->freq_in_seconds_per_sample) - blep(t2, x->freq_in_seconds_per_sample);
-    return(y);
+    x->x_soft = (int)(f != 0);
 }
 
 static t_int* blsquare_perform(t_int *w) {
-    t_polyblep* x      = (t_polyblep*)(w[1]);
+    t_blsquare* x      = (t_blsquare*)(w[1]);
+    t_elliptic_blep* blep = &x->x_elliptic_blep;
     t_int n            = (t_int)(w[2]);
     t_float* freq_vec  = (t_float *)(w[3]);
     t_float* width_vec = (t_float *)(w[4]);
@@ -84,39 +43,54 @@ static t_int* blsquare_perform(t_int *w) {
         t_float sync = *sync_vec++;
         t_float phase_offset = *phase_vec++;
         t_float pulse_width = *width_vec++;
-        if(x->midi)
+        if(x->x_midi && freq < 256)
             freq = pow(2, (freq - 69)/12) * 440;
-        x->freq_in_seconds_per_sample = freq / x->sr; // Update frequency
+        
         // Update pulse width, limit between 0 and 1
-        x->pulse_width = fmax(fmin(0.9999, pulse_width), 0.0001);
-        if(x->soft)
-            x->freq_in_seconds_per_sample *= x->soft;
+        x->x_pulse_width = fmax(fmin(0.99, pulse_width), 0.01);
+        
         if(sync > 0 && sync <= 1){ // Phase sync
-            if(x->soft)
-                x->soft = x->soft == 1 ? -1 : 1;
+            if(x->x_soft)
+                x->x_soft = x->x_soft == 1 ? -1 : 1;
             else{
-                x->phase = sync;
-                x->phase = phasewrap(x->phase);
+                x->x_phase = sync;
+                x->x_phase = phasewrap(x->x_phase);
             }
         }
-        else{ // Phase modulation
-            double phase_dev = phase_offset - x->last_phase_offset;
-            if(phase_dev >= 1 || phase_dev <= -1)
-                phase_dev = fmod(phase_dev, 1);
-            x->phase = phasewrap(x->phase + phase_dev);
+        else { // Phase modulation
+            double phase_dev = phase_offset - x->x_last_phase_offset;
+            x->x_phase = phasewrap(x->x_phase + phase_dev);
         }
-        t_float y = sqr(x);
-        x->phase += x->freq_in_seconds_per_sample;
-        x->phase = phasewrap(x->phase);
-        x->last_phase_offset = phase_offset;
-        *out++ = y;  // Send to output
+        
+        *out++ = (x->x_phase <= x->x_pulse_width ? 1.0f : -1.0f) + elliptic_blep_get(blep);
+        
+        t_float phase_increment = freq / x->x_sr; // Update frequency
+        t_float last_phase = x->x_phase;
+        x->x_phase += phase_increment;
+        if(x->x_soft)
+            phase_increment *= x->x_soft;
+        
+        elliptic_blep_step(blep);
+        
+        if(x->x_phase >= 1 || x->x_phase < 0) {
+            x->x_phase = x->x_phase < 0 ? x->x_phase+1 : x->x_phase-1;
+            t_float samples_in_past = x->x_phase / phase_increment;
+            elliptic_blep_add_in_past(blep, 2.0f, 1, samples_in_past);
+        }
+        else if (x->x_phase >= x->x_pulse_width && x->x_phase < x->x_pulse_width + phase_increment) {
+            t_float samples_in_past = (x->x_phase - x->x_pulse_width) / phase_increment;
+            elliptic_blep_add_in_past(blep, -2.0f, 1, samples_in_past);
+        }
+        
+        x->x_last_phase_offset = phase_offset;
     }
     return(w+8);
 }
 
 static void blsquare_dsp(t_blsquare *x, t_signal **sp){
-    x->x_polyblep.sr = sp[0]->s_sr;
-    dsp_add(blsquare_perform, 7, &x->x_polyblep, sp[0]->s_n, sp[0]->s_vec,
+    x->x_sr = sp[0]->s_sr;
+    elliptic_blep_create(&x->x_elliptic_blep, 0, sp[0]->s_sr);
+    dsp_add(blsquare_perform, 7, x, sp[0]->s_n, sp[0]->s_vec,
         sp[1]->s_vec, sp[2]->s_vec, sp[3]->s_vec, sp[4]->s_vec);
  }
 
@@ -128,25 +102,26 @@ static void blsquare_free(t_blsquare *x){
 
 static void* blsquare_new(t_symbol *s, int ac, t_atom *av){
     s = NULL;
-    t_blsquare* x = (t_blsquare *)pd_new(bl_square);
-    x->x_polyblep.pulse_width = 0.5;
-    x->x_polyblep.freq_in_seconds_per_sample = 0;
-    x->x_polyblep.phase = 0.0;
-    x->x_polyblep.midi = 0;
-    x->x_polyblep.soft = 0;
+    t_blsquare* x = (t_blsquare *)pd_new(blsquare_class);
+    x->x_phase = 0.0;
+    x->x_soft = 0;
+    x->x_midi = 0;
+    x->x_last_phase_offset = 0;
+    x->x_pulse_width = 0.5f;
+    
     t_float init_freq = 0, init_phase = 0;
     while(ac && av->a_type == A_SYMBOL){
         if(atom_getsymbol(av) == gensym("-midi"))
-            x->x_polyblep.midi = 1;
+            x->x_midi = 1;
         else if(atom_getsymbol(av) == gensym("-soft"))
-            x->x_polyblep.soft = 1;
+            x->x_soft = 1;
         ac--, av++;
     }
     if(ac && av->a_type == A_FLOAT){
         init_freq = av->a_w.w_float;
         ac--; av++;
         if(ac && av->a_type == A_FLOAT){
-            x->x_polyblep.pulse_width = av->a_w.w_float;
+            x->x_pulse_width = av->a_w.w_float;
             ac--; av++;
         }
         if(ac && av->a_type == A_FLOAT){
@@ -157,7 +132,7 @@ static void* blsquare_new(t_symbol *s, int ac, t_atom *av){
     x->x_f = init_freq;
     outlet_new(&x->x_obj, &s_signal);
     x->x_inlet_width = inlet_new(&x->x_obj, &x->x_obj.ob_pd,  &s_signal, &s_signal);
-    pd_float((t_pd *)x->x_inlet_width, x->x_polyblep.pulse_width);
+    pd_float((t_pd *)x->x_inlet_width, x->x_pulse_width);
     x->x_inlet_sync = inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
     pd_float((t_pd *)x->x_inlet_sync, 0);
     x->x_inlet_phase = inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
@@ -166,10 +141,10 @@ static void* blsquare_new(t_symbol *s, int ac, t_atom *av){
 }
 
 void setup_bl0x2esquare_tilde(void){
-    bl_square = class_new(gensym("bl.square~"), (t_newmethod)blsquare_new,
+    blsquare_class = class_new(gensym("bl.square~"), (t_newmethod)blsquare_new,
         (t_method)blsquare_free, sizeof(t_blsquare), 0, A_GIMME, A_NULL);
-    CLASS_MAINSIGNALIN(bl_square, t_blsquare, x_f);
-    class_addmethod(bl_square, (t_method)blsquare_soft, gensym("soft"), A_DEFFLOAT, 0);
-    class_addmethod(bl_square, (t_method)blsquare_midi, gensym("midi"), A_DEFFLOAT, 0);
-    class_addmethod(bl_square, (t_method)blsquare_dsp, gensym("dsp"), A_NULL);
+    CLASS_MAINSIGNALIN(blsquare_class, t_blsquare, x_f);
+    class_addmethod(blsquare_class, (t_method)blsquare_soft, gensym("soft"), A_DEFFLOAT, 0);
+    class_addmethod(blsquare_class, (t_method)blsquare_midi, gensym("midi"), A_DEFFLOAT, 0);
+    class_addmethod(blsquare_class, (t_method)blsquare_dsp, gensym("dsp"), A_NULL);
 }

--- a/Source/Audio/bl.square~.c
+++ b/Source/Audio/bl.square~.c
@@ -47,7 +47,8 @@ static t_int* blsquare_perform(t_int *w) {
             freq = pow(2, (freq - 69)/12) * 440;
         
         // Update pulse width, limit between 0 and 1
-        x->x_pulse_width = fmax(fmin(0.99, pulse_width), 0.01);
+        pulse_width = fmax(fmin(0.99, pulse_width), 0.01);
+        x->x_pulse_width = pulse_width;
         
         if(sync > 0 && sync <= 1){ // Phase sync
             if(x->x_soft)

--- a/Source/Audio/bl.tri~.c
+++ b/Source/Audio/bl.tri~.c
@@ -72,11 +72,11 @@ static t_int* bltri_perform(t_int *w) {
         x->x_phase = phasewrap(x->x_phase);
         if(x->x_phase >= 0.25f && x->x_phase < 0.25f + phase_increment) {
             t_float samples_in_past = (x->x_phase - 0.25f) / phase_increment;
-            elliptic_blep_add_in_past(blep, phase_increment * -8.0f, 2, samples_in_past);
+            elliptic_blep_add_in_past(blep, phase_increment * -4.0f, 2, samples_in_past);
         }
         else if (x->x_phase >= 0.75f && x->x_phase < 0.75f + phase_increment) {
             t_float samples_in_past = (x->x_phase - 0.75f) / phase_increment;
-            elliptic_blep_add_in_past(blep, phase_increment * 8.0f, 2, samples_in_past);
+            elliptic_blep_add_in_past(blep, phase_increment * 4.0f, 2, samples_in_past);
         }
         
         

--- a/Source/Audio/bl.tri~.c
+++ b/Source/Audio/bl.tri~.c
@@ -1,89 +1,39 @@
-// License: BSD 2 Clause
-// Created by Timothy Schoen and Porres, based on LabSound polyBLEP oscillators
-
-// Adapted from "Phaseshaping Oscillator Algorithms for Musical Sound
-// Synthesis" by Jari Kleimola, Victor Lazzarini, Joseph Timoney, and Vesa
-// Valimaki. http://www.acoustics.hut.fi/publications/papers/smc2010-phaseshaping/
+// Created by Timothy Schoen and Porres
+// Based on Elliptic BLEP by signalsmith-audio: https://github.com/Signalsmith-Audio/elliptic-blep
 
 #include <m_pd.h>
-#include <math.h>
-#include <stdint.h>
+#include <blep.h>
 
 #define PI     3.1415926535897931
 #define TWO_PI 6.2831853071795862
 
-typedef struct _polyblep{
-    t_float pulse_width;    // Pulse width for square, morph-to-tri for triangle
-    t_float phase;          // The current phase of the oscillator.
-    t_float freq_in_seconds_per_sample;
-    t_int midi;
-    t_int soft;
-    t_float sr;
-    t_float last_phase_offset;
-}t_polyblep;
 
 typedef struct bltri{
     t_object    x_obj;
     t_float     x_f;
-    t_polyblep  x_polyblep;
+    t_elliptic_blep x_elliptic_blep;
     t_inlet*    x_inlet_sync;
     t_inlet*    x_inlet_phase;
+    t_float     x_phase;
+    t_float     x_sr;
+    t_float     x_last_phase_offset;
+    t_int       x_midi;
+    t_int       x_soft;
 }t_bltri;
 
 t_class *bl_tri;
 
 static void bltri_midi(t_bltri *x, t_floatarg f){
-    x->x_polyblep.midi = (int)(f != 0);
+    x->x_midi = (int)(f != 0);
 }
 
 static void bltri_soft(t_bltri *x, t_floatarg f){
-    x->x_polyblep.soft = (int)(f != 0);
-}
-
-static t_float phasewrap(t_float phase){
-    while(phase < 0.0)
-        phase += 1.0;
-    while(phase >= 1.0)
-        phase -= 1.0;
-    return(phase);
-}
-
-static t_float square(t_float x){
-    return(x * x);
-}
-
-static t_float blamp(t_float phase, t_float dt){
-    if(phase < dt){
-        phase = phase / dt - 1.0;
-        return(-1.0 / 3.0 * square(phase) * phase);
-    }
-    else if(phase > 1.0 - dt){
-        phase = (phase - 1.0) / dt + 1.0;
-        return(1.0 / 3.0 * square(phase) * phase);
-    }
-    else
-        return(0.0);
-}
-
-static t_float tri(const t_polyblep* x){
-    t_float t1 = x->phase + 0.25;
-    t1 = phasewrap(t1);
-    t_float t2 = x->phase + 1 - 0.25;
-    t2 = phasewrap(t2);
-    t_float y = x->phase * 2;
-    if(y >= 1.5)
-        y = (y - 2) * 2;
-    else if(y >= 0.5)
-        y = 1 - (y - 0.5) * 2;
-    else
-        y *= 2;
-    y += x->freq_in_seconds_per_sample * 4
-        * (blamp(t1, x->freq_in_seconds_per_sample) - blamp(t2, x->freq_in_seconds_per_sample));
-    return(y);
+    x->x_soft = (int)(f != 0);
 }
 
 static t_int* bltri_perform(t_int *w) {
-    t_polyblep* x      = (t_polyblep*)(w[1]);
+    t_bltri* x =          (t_bltri*)(w[1]);
+    t_elliptic_blep* blep = &x->x_elliptic_blep;
     t_int n            = (t_int)(w[2]);
     t_float* freq_vec  = (t_float *)(w[3]);
     t_float* sync_vec  = (t_float *)(w[4]);
@@ -93,37 +43,52 @@ static t_int* bltri_perform(t_int *w) {
         t_float freq = *freq_vec++;
         t_float sync = *sync_vec++;
         t_float phase_offset = *phase_vec++;
-        if(x->midi)
+
+        if(x->x_midi && freq < 256)
             freq = pow(2, (freq - 69)/12) * 440;
-        x->freq_in_seconds_per_sample = freq / x->sr; // Update frequency
-        if(x->soft)
-            x->freq_in_seconds_per_sample *= x->soft;
+
+        t_float triangle = 2.0f * fabs(2.0f * ((x->x_phase + 0.25f) - floor(x->x_phase + 0.75f))) - 1.0f;
+        *out++ = triangle + elliptic_blep_get(blep);
+        
         if(sync > 0 && sync <= 1){ // Phase sync
-            if(x->soft)
-                x->soft = x->soft == 1 ? -1 : 1;
-            else{
-                x->phase = sync;
-                x->phase = phasewrap(x->phase);
+            if(x->x_soft)
+                x->x_soft = x->x_soft == 1 ? -1 : 1;
+            else {
+                x->x_phase = phasewrap(sync);
             }
         }
-        else{ // Phase modulation
-            double phase_dev = phase_offset - x->last_phase_offset;
-            if(phase_dev >= 1 || phase_dev <= -1)
-                phase_dev = fmod(phase_dev, 1);
-            x->phase = phasewrap(x->phase + phase_dev);
+        else { // Phase modulation
+            double phase_dev = phase_offset - x->x_last_phase_offset;
+            x->x_phase = phasewrap(x->x_phase + phase_dev);
         }
-        t_float y = tri(x);
-        x->phase += x->freq_in_seconds_per_sample;
-        x->phase = phasewrap(x->phase);
-        x->last_phase_offset = phase_offset;
-        *out++ = y;  // Send to output
+        
+        t_float phase_increment = freq / x->x_sr; // Update frequency
+        x->x_phase += phase_increment;
+        if(x->x_soft)
+            phase_increment *= x->x_soft;
+        
+        elliptic_blep_step(blep);
+        
+        x->x_phase = phasewrap(x->x_phase);
+        if(x->x_phase >= 0.25f && x->x_phase < 0.25f + phase_increment) {
+            t_float samples_in_past = (x->x_phase - 0.25f) / phase_increment;
+            elliptic_blep_add_in_past(blep, phase_increment * -8.0f, 2, samples_in_past);
+        }
+        else if (x->x_phase >= 0.75f && x->x_phase < 0.75f + phase_increment) {
+            t_float samples_in_past = (x->x_phase - 0.75f) / phase_increment;
+            elliptic_blep_add_in_past(blep, phase_increment * 8.0f, 2, samples_in_past);
+        }
+        
+        
+        x->x_last_phase_offset = phase_offset;
     }
     return(w+7);
 }
 
 static void bltri_dsp(t_bltri *x, t_signal **sp){
-    x->x_polyblep.sr = sp[0]->s_sr;
-    dsp_add(bltri_perform, 6, &x->x_polyblep, sp[0]->s_n, sp[0]->s_vec,
+    x->x_sr = sp[0]->s_sr;
+    elliptic_blep_create(&x->x_elliptic_blep, 0, sp[0]->s_sr);
+    dsp_add(bltri_perform, 6, x, sp[0]->s_n, sp[0]->s_vec,
             sp[1]->s_vec, sp[2]->s_vec, sp[3]->s_vec);
  }
 
@@ -135,26 +100,21 @@ static void bltri_free(t_bltri *x){
 static void* bltri_new(t_symbol *s, int ac, t_atom *av){
     s = NULL;
     t_bltri* x = (t_bltri *)pd_new(bl_tri);
-    x->x_polyblep.pulse_width = 0;
-    x->x_polyblep.freq_in_seconds_per_sample = 0;
-    x->x_polyblep.phase = 0.0;
-    x->x_polyblep.midi = 0;
-    x->x_polyblep.soft = 0;
+    x->x_phase = 1.0f;
+    x->x_soft = 0;
+    x->x_midi = 0;
+    x->x_last_phase_offset = 0;
     t_float init_freq = 0, init_phase = 0;
     while(ac && av->a_type == A_SYMBOL){
         if(atom_getsymbol(av) == gensym("-midi"))
-            x->x_polyblep.midi = 1;
+            x->x_midi = 1;
         else if(atom_getsymbol(av) == gensym("-soft"))
-            x->x_polyblep.soft = 1;
+            x->x_soft = 1;
         ac--, av++;
     }
     if(ac && av->a_type == A_FLOAT){
         init_freq = av->a_w.w_float;
         ac--; av++;
-        if(ac && av->a_type == A_FLOAT){
-            x->x_polyblep.pulse_width = av->a_w.w_float;
-            ac--; av++;
-        }
         if(ac && av->a_type == A_FLOAT){
             init_phase = av->a_w.w_float;
             ac--; av++;

--- a/Source/Audio/bl.vsaw~.c
+++ b/Source/Audio/bl.vsaw~.c
@@ -1,91 +1,38 @@
-// License: BSD 2 Clause
-// Created by Timothy Schoen and Porres, based on LabSound polyBLEP oscillators
-
-// Adapted from "Phaseshaping Oscillator Algorithms for Musical Sound
-// Synthesis" by Jari Kleimola, Victor Lazzarini, Joseph Timoney, and Vesa
-// Valimaki. http://www.acoustics.hut.fi/publications/papers/smc2010-phaseshaping/
+// Created by Timothy Schoen and Porres
+// Based on Elliptic BLEP by signalsmith-audio: https://github.com/Signalsmith-Audio/elliptic-blep
 
 #include <m_pd.h>
-#include <math.h>
-#include <stdint.h>
-
-#define PI     3.1415926535897931
-#define TWO_PI 6.2831853071795862
-
-typedef struct _polyblep{
-    t_float pulse_width;    // Pulse width for square, morph-to-saw for triangle
-    t_float phase;          // The current phase of the oscillator.
-    t_float freq_in_seconds_per_sample;
-    t_int midi;
-    t_int soft;
-    t_float sr;
-    t_float last_phase_offset;
-}t_polyblep;
+#include <blep.h>
 
 typedef struct blvsaw{
-    t_object x_obj;
-    t_float x_f;
-    t_polyblep x_polyblep;
-    t_inlet* x_inlet_sync;
-    t_inlet* x_inlet_phase;
-    t_inlet* x_inlet_width;
+    t_object    x_obj;
+    t_float     x_f;
+    t_elliptic_blep x_elliptic_blep;
+    t_inlet*    x_inlet_sync;
+    t_inlet*    x_inlet_phase;
+    t_inlet*    x_inlet_width;
+    t_float     x_phase;
+    t_float     x_sr;
+    t_float     x_last_phase_offset;
+    t_float     x_pulse_width;
+    t_int       x_midi;
+    t_int       x_soft;
 }t_blvsaw;
 
-t_class *bl_vsaw;
+t_class *blvsaw_class;
 
 static void blvsaw_midi(t_blvsaw *x, t_floatarg f){
-    x->x_polyblep.midi = (int)(f != 0);
+    x->x_midi = (int)(f != 0);
 }
 
 static void blvsaw_soft(t_blvsaw *x, t_floatarg f){
-    x->x_polyblep.soft = (int)(f != 0);
+    x->x_soft = (int)(f != 0);
 }
 
-static t_float phasewrap(t_float phase){
-    while (phase < 0.0)
-        phase += 1.0;
-    while(phase >= 1.0)
-        phase -= 1.0;
-    return(phase);
-}
-
-static t_float square(t_float x){
-    return(x * x);
-}
-
-static t_float blamp(t_float phase, t_float dt){
-    if(phase < dt){
-        phase = phase / dt - 1.0;
-        return(-1.0 / 3.0 * square(phase) * phase);
-    }
-    else if(phase > 1.0 - dt){
-        phase = (phase - 1.0) / dt + 1.0;
-        return(1.0 / 3.0 * square(phase) * phase);
-    }
-    else
-        return(0.0);
-}
-
-static t_float vsaw(const t_polyblep* x){
-    t_float pulse_width = fmax(0.0001, fmin(0.9999, x->pulse_width));
-    t_float t1 = x->phase + 0.5 * pulse_width;
-    t1 = phasewrap(t1);
-    t_float t2 = x->phase + 1 - 0.5 * pulse_width;
-    t2 = phasewrap(t2);
-    t_float y = x->phase * 2;
-    if(y >= 2 - pulse_width)
-        y = (y - 2) / pulse_width;
-    else if(y >= pulse_width)
-        y = 1 - (y - pulse_width) / (1 - pulse_width);
-    else
-        y /= pulse_width;
-    y += x->freq_in_seconds_per_sample / (pulse_width - pulse_width * pulse_width)
-        * (blamp(t1, x->freq_in_seconds_per_sample) - blamp(t2, x->freq_in_seconds_per_sample));
-    return(y);
-}
 
 static t_int* blvsaw_perform(t_int *w) {
-    t_polyblep* x      = (t_polyblep*)(w[1]);
+    t_blvsaw* x      = (t_blvsaw*)(w[1]);
+    t_elliptic_blep* blep = &x->x_elliptic_blep;
     t_int n            = (t_int)(w[2]);
     t_float* freq_vec  = (t_float *)(w[3]);
     t_float* width_vec = (t_float *)(w[4]);
@@ -97,39 +44,78 @@ static t_int* blvsaw_perform(t_int *w) {
         t_float sync = *sync_vec++;
         t_float phase_offset = *phase_vec++;
         t_float pulse_width = *width_vec++;
-        if(x->midi)
+        if(x->x_midi && freq < 255)
             freq = pow(2, (freq - 69)/12) * 440;
         // Update pulse width, limit between 0 and 1
-        x->pulse_width = fmax(fmin(0.9999, pulse_width), 0.0001);
-        x->freq_in_seconds_per_sample = freq / x->sr; // Update frequency
-        if(x->soft)
-            x->freq_in_seconds_per_sample *= x->soft;
+        x->x_pulse_width = fmax(fmin(0.9999, pulse_width), 0.0001);
+        t_float phase_increment = freq / x->x_sr; // Update frequency
+        if(x->x_soft)
+            phase_increment *= x->x_soft;
         if(sync > 0 && sync <= 1){ // Phase sync
-            if(x->soft)
-                x->soft = x->soft == 1 ? -1 : 1;
+            if(x->x_soft)
+                x->x_soft = x->x_soft == 1 ? -1 : 1;
             else{
-                x->phase = sync;
-                x->phase = phasewrap(x->phase);
+                x->x_phase = sync;
+                x->x_phase = phasewrap(x->x_phase);
             }
         }
         else{ // Phase modulation
-            double phase_dev = phase_offset - x->last_phase_offset;
+            double phase_dev = phase_offset - x->x_last_phase_offset;
             if(phase_dev >= 1 || phase_dev <= -1)
                 phase_dev = fmod(phase_dev, 1);
-            x->phase = phasewrap(x->phase + phase_dev);
+            x->x_phase = phasewrap(x->x_phase + phase_dev);
         }
-        t_float y = vsaw(x);
-        x->phase += x->freq_in_seconds_per_sample;
-        x->phase = phasewrap(x->phase);
-        x->last_phase_offset = phase_offset;
-        *out++ = y;  // Send to output
+        
+        t_float output;
+        if (pulse_width == 0)
+            output = x->x_phase * -2 + 1;
+        else if (pulse_width == 1)
+            output = x->x_phase * 2 - 1;
+        else {
+            t_float inc = x->x_phase * pulse_width;                   // phase * 0.5
+            t_float dec = (x->x_phase - 1) * (pulse_width - 1);       //
+            t_float gain = pow(pulse_width * (pulse_width - 1), -1);
+            t_float min = (inc < dec ? inc : dec);
+            output = (min * gain) * 2 + 1;
+        }
+        
+        *out++ = output + elliptic_blep_get(blep);
+        
+        x->x_phase += phase_increment;
+        if(x->x_soft)
+            phase_increment *= x->x_soft;
+        
+        elliptic_blep_step(blep);
+        
+        if(pulse_width != 0.0f && pulse_width != 1.0f)
+        {
+            if(x->x_phase >= 1 || x->x_phase < 0) {
+                x->x_phase = x->x_phase < 0 ? x->x_phase+1 : x->x_phase-1;
+                t_float samples_in_past = x->x_phase / phase_increment;
+                elliptic_blep_add_in_past(blep, phase_increment * -8.0, 2, samples_in_past);
+            }
+            else if (x->x_phase >= x->x_pulse_width && x->x_phase < x->x_pulse_width + phase_increment) {
+                t_float samples_in_past = (x->x_phase - x->x_pulse_width) / phase_increment;
+                elliptic_blep_add_in_past(blep, phase_increment * 8.0, 2, samples_in_past);
+            }
+        }
+        else {
+            if(x->x_phase >= 1 || x->x_phase < 0) {
+                x->x_phase = x->x_phase < 0 ? x->x_phase+1 : x->x_phase-1;
+                t_float samples_in_past = x->x_phase / phase_increment;
+                elliptic_blep_add_in_past(blep, pulse_width == 0.0f ? 2.0f : -2.0f, 1, samples_in_past);
+            }
+        }
+       
+        x->x_last_phase_offset = phase_offset;
     }
     return(w+8);
 }
 
 static void blvsaw_dsp(t_blvsaw *x, t_signal **sp){
-    x->x_polyblep.sr = sp[0]->s_sr;
-    dsp_add(blvsaw_perform, 7, &x->x_polyblep, sp[0]->s_n, sp[0]->s_vec,
+    x->x_sr = sp[0]->s_sr;
+    elliptic_blep_create(&x->x_elliptic_blep, 0, sp[0]->s_sr);
+    dsp_add(blvsaw_perform, 7, x, sp[0]->s_n, sp[0]->s_vec,
         sp[1]->s_vec, sp[2]->s_vec, sp[3]->s_vec, sp[4]->s_vec);
  }
 
@@ -141,25 +127,26 @@ static void blvsaw_free(t_blvsaw *x){
 
 static void* blvsaw_new(t_symbol *s, int ac, t_atom *av){
     s = NULL;
-    t_blvsaw* x = (t_blvsaw *)pd_new(bl_vsaw);
-    x->x_polyblep.pulse_width = 0;
-    x->x_polyblep.freq_in_seconds_per_sample = 0;
-    x->x_polyblep.phase = 0.0;
-    x->x_polyblep.midi = 0;
-    x->x_polyblep.soft = 0;
+    t_blvsaw* x = (t_blvsaw *)pd_new(blvsaw_class);
+    x->x_pulse_width = 0;
+    x->x_last_phase_offset = 0;
+    x->x_phase = 0.0;
+    x->x_midi = 0;
+    x->x_soft = 0;
+    x->x_pulse_width = 0.5f;
     t_float init_freq = 0, init_phase = 0;
     while(ac && av->a_type == A_SYMBOL){
         if(atom_getsymbol(av) == gensym("-midi"))
-            x->x_polyblep.midi = 1;
+            x->x_midi = 1;
         else if(atom_getsymbol(av) == gensym("-soft"))
-            x->x_polyblep.soft = 1;
+            x->x_soft = 1;
         ac--, av++;
     }
     if(ac && av->a_type == A_FLOAT){
         init_freq = av->a_w.w_float;
         ac--; av++;
         if(ac && av->a_type == A_FLOAT){
-            x->x_polyblep.pulse_width = av->a_w.w_float;
+            x->x_pulse_width = av->a_w.w_float;
             ac--; av++;
         }
         if(ac && av->a_type == A_FLOAT){
@@ -170,7 +157,7 @@ static void* blvsaw_new(t_symbol *s, int ac, t_atom *av){
     x->x_f = init_freq;
     outlet_new(&x->x_obj, &s_signal);
     x->x_inlet_width = inlet_new(&x->x_obj, &x->x_obj.ob_pd,  &s_signal, &s_signal);
-    pd_float((t_pd *)x->x_inlet_width, x->x_polyblep.pulse_width);
+    pd_float((t_pd *)x->x_inlet_width, x->x_pulse_width);
     x->x_inlet_sync = inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
     pd_float((t_pd *)x->x_inlet_sync, 0);
     x->x_inlet_phase = inlet_new(&x->x_obj, &x->x_obj.ob_pd, &s_signal, &s_signal);
@@ -179,10 +166,10 @@ static void* blvsaw_new(t_symbol *s, int ac, t_atom *av){
 }
 
 void setup_bl0x2evsaw_tilde(void){
-    bl_vsaw = class_new(gensym("bl.vsaw~"), (t_newmethod)blvsaw_new,
+    blvsaw_class = class_new(gensym("bl.vsaw~"), (t_newmethod)blvsaw_new,
         (t_method)blvsaw_free, sizeof(t_blvsaw), 0, A_GIMME, A_NULL);
-    CLASS_MAINSIGNALIN(bl_vsaw, t_blvsaw, x_f);
-    class_addmethod(bl_vsaw, (t_method)blvsaw_soft, gensym("soft"), A_DEFFLOAT, 0);
-    class_addmethod(bl_vsaw, (t_method)blvsaw_midi, gensym("midi"), A_DEFFLOAT, 0);
-    class_addmethod(bl_vsaw, (t_method)blvsaw_dsp, gensym("dsp"), A_NULL);
+    CLASS_MAINSIGNALIN(blvsaw_class, t_blvsaw, x_f);
+    class_addmethod(blvsaw_class, (t_method)blvsaw_soft, gensym("soft"), A_DEFFLOAT, 0);
+    class_addmethod(blvsaw_class, (t_method)blvsaw_midi, gensym("midi"), A_DEFFLOAT, 0);
+    class_addmethod(blvsaw_class, (t_method)blvsaw_dsp, gensym("dsp"), A_NULL);
 }

--- a/Source/Audio/conv~.c
+++ b/Source/Audio/conv~.c
@@ -176,7 +176,12 @@ static void conv_set(t_conv *x, t_symbol *arrayName){
         // if we want to assume that a 2nd call to analyze() with the same array name is safe (and we don't have to reload x_vec or update x_array_size), we have to do some careful safety checks to make sure that the size of x_array_name hasn't changed since the last time this was called. If it has, we should just abort for now.
         this_array_size = 0;
         this_array_ptr = (t_garray *)pd_findbyclass(arrayName, garray_class);
-        garray_getfloatwords(this_array_ptr, &this_array_size, &this_vec);
+        if(this_array_ptr) {
+            garray_getfloatwords(this_array_ptr, &this_array_size, &this_vec);
+        }
+        else {
+            pd_error(x, "[conv~]: array %s doesn't exist", arrayName->s_name);
+        }
         if(this_array_size != x->x_array_size){
             pd_error(x, "[conv~]: size of array %s has changed since previous analysis...aborting. Reload %s with previous IR contents or analyze another array.", arrayName->s_name, arrayName->s_name);
             return;

--- a/Source/Audio/cosine~.c
+++ b/Source/Audio/cosine~.c
@@ -66,7 +66,7 @@ static t_int *cosine_perform(t_int *w){
     for(int j = 0; j < x->x_nchans; j++){
         for(int i = 0, n = x->x_n; i < n; i++){
             double hz = x->x_sig1 ? in1[j*n + i] : x->x_freq_list[j];
-            if(x->x_midi)
+            if(x->x_midi && hz < 256)
                 hz = hz <= 0 ? 0 : pow(2, (hz - 69)/12) * 440;
             double step = hz * x->x_sr_rec; // phase step
             step = step > 0.5 ? 0.5 : step < -0.5 ? -0.5 : step;

--- a/Source/Audio/cusp~.c
+++ b/Source/Audio/cusp~.c
@@ -20,14 +20,15 @@ typedef struct _cusp
 
 
 static void cusp_list(t_cusp *x, t_symbol *s, int argc, t_atom * argv){
+    if(argc == 1){
+        if(s) obj_list(&x->x_obj, 0, argc, argv);
+        return;
+    }
+    
     s = NULL;
     int argnum = 0; // current argument
     while(argc)
     {
-        if(argc == 1){
-            obj_list(&x->x_obj, 0, argc, argv);
-            return;
-        }
         if(argv->a_type != A_FLOAT)
             pd_error(x, "cusp~: list needs to only contain floats");
         else{

--- a/Source/Audio/envgen~.c
+++ b/Source/Audio/envgen~.c
@@ -115,7 +115,7 @@ static void envgen_retarget(t_envgen *x, int skip){
         x->x_value = x->x_last_target = x->x_target;
         x->x_delta = x->x_inc = 0;
         x->x_power = x->x_at_exp[x->x_line_n].a_w.w_float;
-        while(x->x_n_lines && // others to be ignored
+        while(x->x_n_lines > 0 && // others to be ignored
               !(int)(x->x_curseg->ms * sys_getsr()*0.001 + 0.5)){
             x->x_value = x->x_target = x->x_curseg->target;
             x->x_n_lines--, x->x_curseg++, x->x_line_n++;

--- a/Source/Audio/fbsine2~.c
+++ b/Source/Audio/fbsine2~.c
@@ -63,12 +63,13 @@ static void fbsine2_coeffs(t_fbsine2 *x, t_symbol *s, int argc, t_atom * argv){
 }
 
 static void fbsine2_list(t_fbsine2 *x, t_symbol *s, int argc, t_atom * argv){
+    if(argc == 1){
+        if(s) obj_list(&x->x_obj, 0, argc, argv);
+        return;
+    }
+    
     s = NULL;
     if(argc){
-        if(argc == 1){
-            obj_list(&x->x_obj, 0, argc, argv);
-            return;
-        }
         if(argc > 2){
             pd_error(x, "fbsine2~: list size needs to be = 2");
             return;

--- a/Source/Audio/gbman~.c
+++ b/Source/Audio/gbman~.c
@@ -19,11 +19,13 @@ typedef struct _gbman{
 }t_gbman;
 
 static void gbman_list(t_gbman *x, t_symbol *s, int ac, t_atom * av){
-    s = NULL;
     if(ac == 1){
-        obj_list(&x->x_obj, 0, ac, av);
+        if(s) obj_list(&x->x_obj, 0, ac, av);
         return;
     }
+    
+    s = NULL;
+
     if(ac != 2)
         pd_error(x, "[gbman~]: list size needs to be = 2");
     else{

--- a/Source/Audio/henon~.c
+++ b/Source/Audio/henon~.c
@@ -30,11 +30,13 @@ static void henon_coeffs(t_henon *x, t_floatarg f1, t_floatarg f2)
 
 static void henon_list(t_henon *x, t_symbol *s, int argc, t_atom * argv)
 {
-    s = NULL;
     if(argc == 1){
-        obj_list(&x->x_obj, 0, argc, argv);
+        if(s) obj_list(&x->x_obj, 0, argc, argv);
         return;
     }
+    
+    s = NULL;
+
     if (argc != 2)
         {
         pd_error(x, "henon~: list size needs to be = 2");
@@ -144,17 +146,21 @@ static void *henon_new(t_symbol *s, int ac, t_atom *av)
     {
         hz = av->a_w.w_float;
         ac--; av++;
-        if (ac && av->a_type == A_FLOAT)
+        if (ac && av->a_type == A_FLOAT) {
             a = av->a_w.w_float;
             ac--; av++;
-            if (ac && av->a_type == A_FLOAT)
+            if (ac && av->a_type == A_FLOAT) {
                 b = av->a_w.w_float;
                 ac--; av++;
-                if (ac && av->a_type == A_FLOAT)
+                if (ac && av->a_type == A_FLOAT) {
                     y_nm1 = av->a_w.w_float;
                     ac--; av++;
-                    if (ac && av->a_type == A_FLOAT)
+                    if (ac && av->a_type == A_FLOAT) {
                         y_nm2 = av->a_w.w_float;
+                    }
+                }
+            }
+        }
     }
     if(hz >= 0) x->x_phase = 1;
     x->x_freq  = hz;

--- a/Source/Audio/ikeda~.c
+++ b/Source/Audio/ikeda~.c
@@ -30,11 +30,12 @@ static void ikeda_clear(t_ikeda *x)
 
 static void ikeda_list(t_ikeda *x, t_symbol *s, int argc, t_atom * argv)
 {
-    s = NULL;
     if(argc == 1){
-        obj_list(&x->x_obj, 0, argc, argv);
+        if(s) obj_list(&x->x_obj, 0, argc, argv);
         return;
     }
+    s = NULL;
+
     if (argc != 2)
         {
         pd_error(x, "ikeda~: list size needs to be = 2");

--- a/Source/Audio/impulse~.c
+++ b/Source/Audio/impulse~.c
@@ -60,7 +60,7 @@ static t_int *impulse_perform(t_int *w){
     for(int j = 0; j < x->x_nchans; j++){
         for(int i = 0, n = x->x_n; i < n; i++){
             double hz = x->x_sig1 ? in1[j*n + i] : x->x_freq_list[j];
-            if(x->x_midi)
+            if(x->x_midi && hz < 256)
                 hz = hz <= 0 ? 0 : pow(2, (hz - 69)/12) * 440;
             double step = hz * x->x_sr_rec; // phase step
             step = step > 1 ? 1 : step < -1 ? -1 : step; // clipped phase_step

--- a/Source/Audio/latoocarfian~.c
+++ b/Source/Audio/latoocarfian~.c
@@ -67,11 +67,13 @@ static void latoocarfian_coeffs(t_latoocarfian *x, t_symbol *s, int argc, t_atom
 
 static void latoocarfian_list(t_latoocarfian *x, t_symbol *s, int argc, t_atom * argv)
 {
-    s = NULL;
     if(argc == 1){
-        obj_list(&x->x_obj, 0, argc, argv);
+        if(s) obj_list(&x->x_obj, 0, argc, argv);
         return;
     }
+    
+    s = NULL;
+
     if (argc != 2)
         pd_error(x, "latoocarfian~: list size needs to be = 2");
     else{

--- a/Source/Audio/lincong~.c
+++ b/Source/Audio/lincong~.c
@@ -20,13 +20,15 @@ typedef struct _lincong{
 }t_lincong;
 
 static void lincong_list(t_lincong *x, t_symbol *s, int argc, t_atom * argv){
+    if(argc == 1){
+        if(s) obj_list(&x->x_obj, 0, argc, argv);
+        return;
+    }
+    
     s = NULL;
     int argnum = 0; // current argument
     while(argc){
-        if(argc == 1){
-            obj_list(&x->x_obj, 0, argc, argv);
-            return;
-        }
+
         if(argv -> a_type != A_FLOAT)
             pd_error(x, "lincong~: list needs to only contain floats");
         else{

--- a/Source/Audio/lorenz~.c
+++ b/Source/Audio/lorenz~.c
@@ -68,12 +68,14 @@ static void lorenz_coeffs(t_lorenz *x, t_symbol *s, int argc, t_atom * argv){
 }
 
 static void lorenz_list(t_lorenz *x, t_symbol *s, int argc, t_atom * argv){
+    if(argc == 1){
+        if(s) obj_list(&x->x_obj, 0, argc, argv);
+        return;
+    }
+    
     s = NULL;
     if(argc){
-        if(argc == 1){
-            obj_list(&x->x_obj, 0, argc, argv);
-            return;
-        }
+
         if(argc > 3){
             pd_error(x, "[lorenz~]: list size needs to be <= 3");
             return;

--- a/Source/Audio/pdlink~.c
+++ b/Source/Audio/pdlink~.c
@@ -3,7 +3,7 @@
  */
 
 #ifndef ENABLE_OPUS
-#define ENABLE_OPUS 0
+#define ENABLE_OPUS 1
 #endif
 
 #include "m_pd.h"

--- a/Source/Audio/pdlink~.c
+++ b/Source/Audio/pdlink~.c
@@ -2,11 +2,17 @@
  * include the interface to Pd
  */
 
+#ifndef ENABLE_OPUS
+#define ENABLE_OPUS 1
+#endif
+
 #include "m_pd.h"
 #include "magic.h"
 #include "else_alloca.h"
 #include "link.h"
+#if ENABLE_OPUS
 #include "opus_compression.h"
+#endif
 #include <samplerate.h>
 #include <stdio.h>
 #include <string.h>
@@ -473,7 +479,11 @@ static void *pdlink_tilde_new(t_symbol *s, int argc, t_atom *argv)
             } else if (strcmp(sym->s_name, "-debug") == 0) {
                 x->x_debug = 1; // Enable debug logging
             }  else if (strcmp(sym->s_name, "-compress") == 0) {
+#if ENABLE_OPUS
                 x->x_compress = 1; // Enable opus compression
+#else
+                pd_error(x, "[pdlink~] opus compression was disabled for this build");
+#endif
             } else if(strcmp(sym->s_name, "-bufsize") == 0 && i < argc-1 && argv[i+1].a_type == A_FLOAT) {
                 i++;
                 x->x_delay = atom_getfloat(argv + i);

--- a/Source/Audio/pimp~.c
+++ b/Source/Audio/pimp~.c
@@ -71,7 +71,7 @@ static t_int *pimp_perform(t_int *w){
     for(int j = 0; j < x->x_nchans; j++){
         for(int i = 0, n = x->x_n; i < n; i++){
             double hz = x->x_sig1 ? in1[j*n + i] : x->x_freq_list[j];
-            if(x->x_midi)
+            if(x->x_midi && hz < 256)
                 hz = hz <= 0 ? 0 : pow(2, (hz - 69)/12) * 440;
             double step = hz * x->x_sr_rec; // phase step
             step = step > 1 ? 1 : step < -1 ? -1 : step; // clipped phase_step

--- a/Source/Audio/plaits~/plaits~.cpp
+++ b/Source/Audio/plaits~/plaits~.cpp
@@ -152,25 +152,27 @@ void plaits_dump(t_plaits *x){
 }
 
 void plaits_list(t_plaits *x, t_symbol *s, int ac, t_atom *av){
-    s = NULL;
+    
     if(ac == 0)
         return;
-    if(ac == 1)
+    if(ac == 1 && s)
         obj_list(&x->x_obj, NULL, ac, av);
-    else if(ac == 2){
+    else if(ac == 2 && s){
         t_atom at[3];
         SETFLOAT(at, atom_getfloat(av));
         SETFLOAT(at+1, atom_getfloat(av+1) / 127.);
         SETFLOAT(at+2, atom_getfloat(av+1) / 127.);
         obj_list(&x->x_obj, NULL, 3, at);
     }
-    else if(ac == 3){
+    else if(ac == 3 && s){
         t_atom at[3];
         SETFLOAT(at, atom_getfloat(av));
         SETFLOAT(at+1, atom_getfloat(av+1) / 127.);
         SETFLOAT(at+2, atom_getfloat(av+2) / 127.);
         obj_list(&x->x_obj, NULL, 3, at);
     }
+    
+    s = NULL;
     x->x_midi_tr = x->x_midi_lvl = 0;
     x->x_midi_pitch = atom_getfloat(av);
     ac--, av++;

--- a/Source/Audio/pluck~.c
+++ b/Source/Audio/pluck~.c
@@ -99,10 +99,7 @@ static void pluck_list(t_pluck *x, t_symbol *s, int argc, t_atom *argv){
     x->x_ignore = s;
     if(argc == 0)
         return;
-    if(argc == 1){
-        obj_list(&x->x_obj, NULL, 1, argv);
-        return;
-    }
+
     if(atom_getfloat(argv+1) == 0)
         return;
     if(argc >= 2){
@@ -200,7 +197,7 @@ static t_int *pluck_perform_noise_input(t_int *w){
             xnm1 = ynm1 = 0;
         }
         else{
-            if(x->x_midi)
+            if(x->x_midi && hz < 256)
                 hz = pow(2, (hz - 69)/12) * 440;
             if(hz != x->x_hz){
                 update_time(x, x->x_hz = hz);
@@ -285,7 +282,7 @@ static t_int *pluck_perform(t_int *w){
             xnm1 = ynm1 = 0;
         }
         else{
-            if(x->x_midi)
+            if(x->x_midi && hz < 256)
                 hz = pow(2, (hz - 69)/12) * 440;
             if(hz != x->x_hz){
                 update_time(x, x->x_hz = hz);
@@ -427,7 +424,7 @@ static void *pluck_new(t_symbol *s, int argc, t_atom *argv){
     pluck_clear(x);
     x->x_hz = x->x_freq = (double)freq;
 
-    if(x->x_midi)
+    if(x->x_midi && x->x_hz < 256)
         x->x_hz  = pow(2, (x->x_hz  - 69)/12) * 440;
 
     x->x_ain = decay;

--- a/Source/Audio/quad~.c
+++ b/Source/Audio/quad~.c
@@ -21,14 +21,15 @@ typedef struct _quad
 
 static void quad_list(t_quad *x, t_symbol *s, int argc, t_atom * argv)
 {
+    if(argc == 1){
+        if(s) obj_list(&x->x_obj, 0, argc, argv);
+        return;
+    }
+    
     s = NULL;
     int argnum = 0; // current argument
     while(argc)
     {
-        if(argc == 1){
-            obj_list(&x->x_obj, 0, argc, argv);
-            return;
-        }
         if(argv -> a_type != A_FLOAT)
         {
             pd_error(x, "latoocarfian~: list arguments needs to only contain floats");
@@ -120,17 +121,21 @@ static void *quad_new(t_symbol *s, int ac, t_atom *av){
     if(ac && av->a_type == A_FLOAT){
         hz = av->a_w.w_float;
         ac--; av++;
-        if (ac && av->a_type == A_FLOAT)
+        if (ac && av->a_type == A_FLOAT) {
             a = av->a_w.w_float;
             ac--; av++;
-            if (ac && av->a_type == A_FLOAT)
+            if (ac && av->a_type == A_FLOAT) {
                 b = av->a_w.w_float;
                 ac--; av++;
-                if (ac && av->a_type == A_FLOAT)
+                if (ac && av->a_type == A_FLOAT) {
                     c = av->a_w.w_float;
                     ac--; av++;
-                    if (ac && av->a_type == A_FLOAT)
+                    if (ac && av->a_type == A_FLOAT) {
                         yn = av->a_w.w_float;
+                    }
+                }
+            }
+        }
     }
     if(hz >= 0) x->x_phase = 1;
     x->x_freq  = hz;

--- a/Source/Audio/sfont~/sfont~.c
+++ b/Source/Audio/sfont~/sfont~.c
@@ -166,7 +166,7 @@ static void sfont_bank(t_sfont *x, t_symbol *s, int ac, t_atom *av){
             return;
         }
         int fail = fluid_synth_bank_select(x->x_synth, ch, bank);
-        if(!fail){
+        if(!fail && x->x_sfont){
             x->x_bank = bank;
             fluid_preset_t* preset = fluid_sfont_get_preset(x->x_sfont, x->x_bank, x->x_pgm);
             if(preset == NULL){

--- a/Source/Audio/sine~.c
+++ b/Source/Audio/sine~.c
@@ -66,7 +66,7 @@ static t_int *sine_perform(t_int *w){
     for(int j = 0; j < x->x_nchans; j++){
         for(int i = 0, n = x->x_n; i < n; i++){
             double hz = x->x_sig1 ? in1[j*n + i] : x->x_freq_list[j];
-            if(x->x_midi)
+            if(x->x_midi && hz < 256)
                 hz = hz <= 0 ? 0 : pow(2, (hz - 69)/12) * 440;
             double step = hz * x->x_sr_rec; // phase step
             step = step > 0.5 ? 0.5 : step < -0.5 ? -0.5 : step;

--- a/Source/Audio/slew2~.c
+++ b/Source/Audio/slew2~.c
@@ -66,6 +66,7 @@ static void slew2_dsp(t_slew2 *x, t_signal **sp){
 
 static void slew2_set(t_slew2 *x, t_symbol *s, int ac, t_atom *av){
     s = NULL;
+    if(ac > x->x_nchans) ac = x->x_nchans;
     for(int i = 0; i < ac; i++)
         x->x_last[i] = atom_getfloat(av++);
 }

--- a/Source/Audio/slew~.c
+++ b/Source/Audio/slew~.c
@@ -62,6 +62,7 @@ static void slew_dsp(t_slew *x, t_signal **sp){
 
 static void slew_set(t_slew *x, t_symbol *s, int ac, t_atom *av){
     s = NULL;
+    if(ac > x->x_nchans) ac = x->x_nchans;
     for(int i = 0; i < ac; i++)
         x->x_lastin[i] = atom_getfloat(av++);
 }

--- a/Source/Audio/standard~.c
+++ b/Source/Audio/standard~.c
@@ -31,11 +31,12 @@ static void standard_k(t_standard *x, t_float f)
 
 static void standard_list(t_standard *x, t_symbol *s, int argc, t_atom * argv)
 {
-    s= NULL;
     if(argc == 1){
-        obj_list(&x->x_obj, 0, argc, argv);
+        if(s) obj_list(&x->x_obj, 0, argc, argv);
         return;
     }
+    s = NULL;
+    
     if (argc > 2)
         {
         pd_error(x, "standard~: list size needs to be = 2");

--- a/Source/Audio/tabwriter~.c
+++ b/Source/Audio/tabwriter~.c
@@ -232,6 +232,8 @@ static void tabwriter_end(t_tabwriter *x, t_float end){
 }
 
 static void tabwriter_range(t_tabwriter *x, t_floatarg f1, t_floatarg f2){
+    if(!x->x_buffer) return;
+    
     f1 = f1 < 0 ? 0 : f1 > 1 ? 1 : f1;
     f2 = f2 < 0 ? 0 : f2 > 1 ? 1 : f2;
     x->x_startindex = (unsigned long long)(f1 * x->x_buffer->c_npts);

--- a/Source/Audio/unmerge~.c
+++ b/Source/Audio/unmerge~.c
@@ -12,6 +12,7 @@ typedef struct _unmerge{
 
 static void unmerge_float(t_unmerge *x, t_floatarg f){
     x->x_ch = f < 1 ? 1 : (int)f;
+    x->x_ch = x->x_ch > 8 ? 8 : (int)x->x_ch;
     canvas_update_dsp();
 }
 
@@ -23,11 +24,12 @@ static void unmerge_dsp(t_unmerge *x, t_signal **sp){
             dsp_add_zero(sp[i+1]->s_vec, n);
         }
         else{
-            if(i == x->x_n){
+            if(i == x->x_n || ch > chs) {
                 signal_setmultiout(&sp[i+1], chs);
                 dsp_add_copy(sp[0]->s_vec + i*ch*n, sp[i+1]->s_vec, chs*n);
+                break;
             }
-            else{
+            else {
                 signal_setmultiout(&sp[i+1], ch);
                 dsp_add_copy(sp[0]->s_vec + i*ch*n, sp[i+1]->s_vec, ch*n);
             }

--- a/Source/Control/canvas.name.c
+++ b/Source/Control/canvas.name.c
@@ -24,7 +24,7 @@ static void canvas_name_depth(t_canvas_name *x, t_floatarg depth){
     }
     else{
         canvas = canvas_getcurrent();
-        while(depth-- && canvas->gl_owner)
+        while(depth-- && canvas && canvas->gl_owner)
             canvas = canvas->gl_owner;
     }
     char buf[MAXPDSTRING];

--- a/Source/Control/function.c
+++ b/Source/Control/function.c
@@ -416,7 +416,7 @@ static void function_float(t_function *x, t_floatarg f){
     if(f >= 1){
         val = x->x_points[x->x_n_states];
         outlet_float(x->x_obj.ob_outlet, val);
-        if(x->x_send != &s_)
+        if(x->x_send != &s_ && x->x_send->s_thing)
             pd_float(x->x_send->s_thing, f);
         return;
     }
@@ -430,7 +430,7 @@ static void function_float(t_function *x, t_floatarg f){
     val = x->x_points[x->x_state-1] + (f-x->x_dur[x->x_state-1]) * (x->x_points[x->x_state] - x->x_points[x->x_state-1])
         / (x->x_dur[x->x_state] - x->x_dur[x->x_state-1]);
     outlet_float(x->x_obj.ob_outlet,val);
-    if(x->x_send != &s_)
+    if(x->x_send != &s_ && x->x_send->s_thing)
         pd_float(x->x_send->s_thing, val);
 }
 

--- a/Source/Control/midi.c
+++ b/Source/Control/midi.c
@@ -961,6 +961,9 @@ static void *midi_new(t_symbol * s, int ac, t_atom *av){
                 ac--, av++;
             }
         }
+        else{
+            break;
+        }
     };
     x->x_clock = clock_new(x, (t_method)midi_clocktick);
     x->x_slaveclock = clock_new(x, (t_method)midi_slaveclocktick);

--- a/Source/Control/sfload.c
+++ b/Source/Control/sfload.c
@@ -8,10 +8,6 @@
 
 #define FRAMES 4096
 
-typedef struct _avstream{
-
-}t_avstream;
-
 static t_class *sfload_class;
 
 typedef struct _sfload{

--- a/Source/Control/voices.c
+++ b/Source/Control/voices.c
@@ -396,10 +396,10 @@ static void *voices_new(t_symbol *s, int ac, t_atom *av){
     x->x_release = release < 0 ? 0 : release;
     x->x_retrig = retrig < 0 ? 0 : retrig > 2 ? 2 : retrig;
     x->x_n = n < 1 ? 1 : n;
-    x->x_vec = (t_voice *)getbytes(n * sizeof(*x->x_vec));
+    x->x_vec = (t_voice *)getbytes(x->x_n * sizeof(*x->x_vec));
     int i;
     t_voice *v;
-    for(v = x->x_vec, i = n; i--; v++){ // initialize voices
+    for(v = x->x_vec, i = x->x_n; i--; v++){ // initialize voices
         v->v_pitch = v->v_used = v->v_count = 0;
         v->v_pitchsym = NULL;
         v->v_clock = clock_new(v, (t_method)voice_tick);

--- a/Source/Extra/Aliases/imp~.c
+++ b/Source/Extra/Aliases/imp~.c
@@ -60,7 +60,7 @@ static t_int *imp_perform(t_int *w){
     for(int j = 0; j < x->x_nchans; j++){
         for(int i = 0, n = x->x_n; i < n; i++){
             double hz = x->x_sig1 ? in1[j*n + i] : x->x_freq_list[j];
-            if(x->x_midi)
+            if(x->x_midi && hz < 256)
                 hz = hz <= 0 ? 0 : pow(2, (hz - 69)/12) * 440;
             double step = hz * x->x_sr_rec; // phase step
             step = step > 1 ? 1 : step < -1 ? -1 : step; // clipped phase_step

--- a/Source/Shared/blep.h
+++ b/Source/Shared/blep.h
@@ -1,0 +1,206 @@
+//
+//  main.cpp
+//  elliptic-blep
+//
+//  Created by Timothy Schoen on 13/11/2024.
+//
+
+#include <complex.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define _USE_MATH_DEFINES
+#include <math.h>
+
+#define t_float float
+#define t_complex _Complex t_float
+
+#define partial_step_count 127
+#define max_integrals 3
+#define max_blep_order max_integrals
+#define complex_count 6
+#define real_count 2
+#define count (complex_count + real_count)
+
+typedef struct {
+    t_complex complex_poles[complex_count];
+    t_complex real_poles[complex_count];
+    // Coeffs for direct bandlimited synthesis of a polynomial-segment waveform
+    t_complex complex_coeffs_direct[complex_count];
+    t_float real_coeffs_direct[real_count];
+    // Coeffs for cancelling the aliasing from discontinuities in an existing waveform
+    t_complex complex_coeffs_blep[complex_count];
+    t_float real_coeffs_blep[real_count];
+} t_elliptic_blep_coeffs;
+
+typedef struct
+{
+    t_complex coeffs[count];
+    t_complex state[count];
+    t_complex blep_coeffs[max_blep_order+1][count];
+
+    // Lookup table for powf(pole, fractional)
+    t_complex partial_step_poles[partial_step_count+1][count];
+} t_elliptic_blep;
+
+static void elliptic_blep_coeffs_init (t_elliptic_blep_coeffs *coeffs)
+{
+    coeffs->complex_poles[0] = -9.999999999999968 + 17.320508075688757 * I;
+    coeffs->complex_poles[1] = -5562.019693104996 + 7721.557745942449 * I;
+    coeffs->complex_poles[2] = -3936.754373279431 + 13650.191094084097 * I;
+    coeffs->complex_poles[3] = -2348.1627071584026 + 17360.269257396852 * I;
+    coeffs->complex_poles[4] = -1177.6059328793112 + 19350.807275259638 * I;
+    coeffs->complex_poles[5] = -351.8405852427604 + 20192.24393379015 * I;
+
+    coeffs->real_poles[0] = -20.000000000000025;
+    coeffs->real_poles[1] = -6298.035731484052;
+
+    coeffs->complex_coeffs_direct[0] = -20.13756830149893 - 11.467013478535181 * I;
+    coeffs->complex_coeffs_direct[1] = -16453.812748230637 - 7298.835752208561 * I;
+    coeffs->complex_coeffs_direct[2] = 7771.069750908201 + 9555.31023870685 * I;
+    coeffs->complex_coeffs_direct[3] = -825.3820172192254 - 6790.877301990311 * I;
+    coeffs->complex_coeffs_direct[4] = -1529.6770476201002 + 2560.1909145592135 * I;
+    coeffs->complex_coeffs_direct[5] = 755.260843981231 - 310.336256340709 * I;
+
+    coeffs->real_coeffs_direct[0] = -20.138060433528526;
+    coeffs->real_coeffs_direct[1] = 10325.52721970985;
+
+    coeffs->complex_coeffs_blep[0] = -0.1375683014988951 + 0.0799919052573852 * I;
+    coeffs->complex_coeffs_blep[1] = -16453.812748230637 - 7298.835752208561 * I;
+    coeffs->complex_coeffs_blep[2] = 7771.069750908201 + 9555.31023870685 * I;
+    coeffs->complex_coeffs_blep[3] = -825.3820172192254 - 6790.877301990311 * I;
+    coeffs->complex_coeffs_blep[4] = -1529.6770476201002 + 2560.1909145592135 * I;
+    coeffs->complex_coeffs_blep[5] = 755.260843981231 - 310.336256340709 * I;
+
+    coeffs->real_coeffs_blep[0] = -0.13806043352856534;
+    coeffs->real_coeffs_blep[1] = 10325.52721970985;
+}
+
+static void elliptic_blep_add_pole(t_elliptic_blep *blep, size_t index, t_complex pole, t_complex coeff, t_float angular_frequency)
+{
+    blep->coeffs[index] = coeff*angular_frequency;
+
+    // Set up partial powers of the pole (so we can move forward/back by fractional samples)
+    for (size_t s = 0; s <= partial_step_count; ++s) {
+        t_float partial = ((t_float)s)/partial_step_count;
+        blep->partial_step_poles[s][index] = cexp(partial*pole*angular_frequency);
+    }
+
+    // Set up
+    t_complex blepCoeff = 1.0;
+    for (size_t o = 0; o <= max_blep_order; ++o) {
+        blep->blep_coeffs[o][index] = blepCoeff;
+        blepCoeff /= pole*angular_frequency; // factor from integrating
+    }
+}
+
+static void elliptic_blep_create(t_elliptic_blep *blep, int direct, t_float srate) {
+    t_elliptic_blep_coeffs s_plane_coeffs; // S-plane (continuous time) filter
+    elliptic_blep_coeffs_init(&s_plane_coeffs);
+
+    t_float angular_frequency = (2*M_PI)/srate;
+
+    // For now, just cast real poles to complex ones
+    const t_float *realCoeffs = (direct ? s_plane_coeffs.real_coeffs_direct : s_plane_coeffs.real_coeffs_blep);
+    for (size_t i = 0; i < real_count; ++i) {
+        elliptic_blep_add_pole(blep, i, s_plane_coeffs.real_poles[i], realCoeffs[i], angular_frequency);
+    }
+    const t_complex *complexCoeffs = (direct ? s_plane_coeffs.complex_coeffs_direct : s_plane_coeffs.complex_coeffs_blep);
+    for (size_t i = 0; i < complex_count; ++i) {
+        elliptic_blep_add_pole(blep, i + real_count, s_plane_coeffs.complex_poles[i], complexCoeffs[i], angular_frequency);
+    }
+}
+
+static t_float elliptic_blep_get(t_elliptic_blep* blep) {
+    t_float sum = 0;
+    for (size_t i = 0; i < count; ++i) {
+        sum += creal(blep->state[i]*blep->coeffs[i]);
+    }
+    return sum;
+}
+
+static void elliptic_blep_add(t_elliptic_blep *blep, t_float amount, size_t blep_order) {
+    if (blep_order > max_blep_order) return;
+    t_complex* bc = blep->blep_coeffs[blep_order];
+
+    for (size_t i = 0; i < count; ++i) {
+        blep->state[i] += amount*bc[i];
+    }
+}
+
+static void elliptic_blep_add_in_past(t_elliptic_blep *blep, t_float amount, size_t blep_order, t_float samplesInPast) {
+    if (blep_order > max_blep_order) return;
+
+    t_complex *bc = blep->blep_coeffs[blep_order];
+
+    t_float table_index = samplesInPast*partial_step_count;
+
+    size_t int_index = floor(table_index);
+    t_float frac_index = table_index - floor(table_index);
+
+    // move the pulse along in time, the same way as state progresses in .step()
+    t_complex *low_poles = blep->partial_step_poles[int_index];
+    t_complex *high_poles = blep->partial_step_poles[int_index + 1];
+    for (size_t i = 0; i < count; ++i) {
+        t_complex lerp_pole = low_poles[i] + (high_poles[i] - low_poles[i])*frac_index;
+        blep->state[i] += bc[i]*lerp_pole*amount;
+    }
+}
+
+static void elliptic_blep_step(t_elliptic_blep *blep) {
+    t_float sum = 0;
+    const t_complex *poles = blep->partial_step_poles[partial_step_count-1];
+    for (size_t i = 0; i < count; ++i) {
+        sum += creal(blep->state[i]*blep->coeffs[i]);
+        blep->state[i] *= poles[i];
+    }
+}
+
+static void elliptic_blep_step_samples(t_elliptic_blep *blep, t_float samples) {
+    t_float table_index = samples*partial_step_count;
+    size_t int_index = floor(table_index);
+    t_float frac_index = table_index - floor(table_index);
+    while (int_index >= partial_step_count) {
+        elliptic_blep_step(blep);
+        int_index -= partial_step_count;
+    }
+
+    t_complex *low_poles = blep->partial_step_poles[int_index];
+    t_complex *high_poles = blep->partial_step_poles[int_index + 1];
+
+    for (size_t i = 0; i < count; ++i) {
+        t_complex lerp_pole = low_poles[i] + (high_poles[i] - low_poles[i])*frac_index;
+        blep->state[i] *= lerp_pole;
+    }
+}
+
+static t_float phasewrap(t_float phase){
+    while(phase < 0.0)
+        phase += 1.0;
+    while(phase >= 1.0)
+        phase -= 1.0;
+    return(phase);
+}
+
+static t_float saw(t_float phase, t_float increment)
+{
+    return 1.0 - 2.0 * phase;
+}
+static t_float square(t_float phase, t_float increment)
+{
+    return (phase < 0.5) ? 1.0 : -1.0;
+}
+static t_float triangle(t_float phase, t_float increment)
+{
+    return 2.0 * fabs(2.0 * (phase - floor(phase + 0.5))) - 1.0;
+}
+
+static t_float sine(t_float phase, t_float increment)
+{
+    return sin(phase * M_PI * 2.0);
+}
+
+static t_float imp(t_float phase, t_float increment)
+{
+    return (phase < increment);
+}

--- a/Source/Shared/link/udp/udp_socket.hpp
+++ b/Source/Shared/link/udp/udp_socket.hpp
@@ -19,7 +19,7 @@ typedef SSIZE_T ssize_t;
 #include <unistd.h>
 #include <arpa/inet.h>
 #include <fcntl.h>
-#ifdef BSD
+#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__BSD__)
 #include <netinet/in.h>
 #include <sys/socket.h>
 #endif

--- a/Source/Shared/link/udp/udp_socket.hpp
+++ b/Source/Shared/link/udp/udp_socket.hpp
@@ -19,6 +19,10 @@ typedef SSIZE_T ssize_t;
 #include <unistd.h>
 #include <arpa/inet.h>
 #include <fcntl.h>
+#ifdef BSD
+#include <netinet/in.h>
+#include <sys/socket.h>
+#endif
 static const int INVALID_SOCKET = -1;
 static const int SOCKET_ERROR   = -1;
 using SOCKET = int;


### PR DESCRIPTION
Contains:
- Flag to disable Opus in pdlink~, in case it creates compilation issues (on rpi for example)
- Fixes to allow compilation on BSD
- Fixes for many small bugs I discovered by fuzzing objects with random arguments and messages
- Improved band-limited oscillators: [bl.saw~], [bl.saw2~], [bl.vsaw~], [bl.square~], [bl.tri~], [bl.imp~] and [bl.imp2~]
   - Based on [elliptic blep](https://github.com/Signalsmith-Audio/elliptic-blep), should provide better anti-aliasing
   - [bl.vsaw~] still has a bit of aliasing with a very small pulse width. I hope to send a fix for that soon
   - Most oscillators don't AA properly for FM or sync. This was already a problem before this update. It should be possible to fix this with the elliptic blep method, but I have not yet figured out how exactly.