### PR TITLE
Avoid -Wmisleading-indentation

### DIFF
--- a/Source/Audio/square~.c
+++ b/Source/Audio/square~.c
@@ -199,10 +199,12 @@ static void *square_new(t_symbol *s, int ac, t_atom *av)
         f1 = av->a_w.w_float;
         ac--; av++;
         if (ac && av->a_type == A_FLOAT)
+        {
             f2 = av->a_w.w_float;
             ac--; av++;
             if (ac && av->a_type == A_FLOAT)
                 f3 = av->a_w.w_float;
+        }
     }
     t_float init_freq = f1;
     t_float init_width = f2;


### PR DESCRIPTION
Small fix from compiling with `-Wall -Werror`.

```
.../pd-else/Source/Audio/square~.c:203:13: error: misleading indentation; statement is not part of the previous 'if' [-Werror,-Wmisleading-indentation]
```